### PR TITLE
chore: edit `createEvent` to infer parameter type of return function

### DIFF
--- a/packages/src/context/context.ts
+++ b/packages/src/context/context.ts
@@ -13,8 +13,8 @@ export type OverlayControllerProps = {
 export type OverlayContextValue = {
   overlayList: string[];
   open: (value: { controller: OverlayControllerComponent; overlayId: string }) => void;
-  close: (id: string) => void;
-  unmount: (id: string) => void;
+  close: (overlayId: string) => void;
+  unmount: (overlayId: string) => void;
   closeAll: () => void;
   unmountAll: () => void;
 };

--- a/packages/src/utils/create-use-external-events.ts
+++ b/packages/src/utils/create-use-external-events.ts
@@ -37,13 +37,7 @@ export function createUseExternalEvents<EventHandlers extends Record<string, (pa
   }
 
   function createEvent<EventKey extends keyof EventHandlers>(event: EventKey) {
-    type Parameter = Parameters<EventHandlers[EventKey]>[0];
-
-    /**
-     * @description `undefined`타입을 갖고 있다면 optional하게 타입을 변경하는 Hacky한 코드
-     */
-    return (...payload: Parameter extends undefined ? [undefined?] : [Parameter]) =>
-      dispatchEvent(`${prefix}:${String(event)}`, payload[0]);
+    return (...payload: Parameters<EventHandlers[EventKey]>) => dispatchEvent(`${prefix}:${String(event)}`, payload[0]);
   }
 
   return [useExternalEvents, createEvent] as const;


### PR DESCRIPTION
Previously `createEvent` function used a _hacky_ method to make a parameter optional when it had `undefined` in its `payload`.
However, this method made TypeScript unable to infer the names of the parameters correctly.

This resulted in issues such as:
```ts
overlay.close(payload_0: string)
overlay.closeAll(payload_0?: undefined)
```

TypeScript inferred the parameters as `payload_0: string` or `payload_0?: undefined`, which is not ideal.
To resolve this, changes were made so that TypeScript can correctly infer the parameter types alongside the inserted `EventKey`.

After the changes, the parameter types are correctly inferred as:
```ts
overlay.close(overlayId: string)
overlay.closeAll()
```

Now, it appears the same as the documentation. The documentation correctly showed `overlay.close(overlayId: string)` and `overlay.closeAll()`, but the code did not reflect this.

Here’s a visual comparison of the before and after:

Before:
![overlay.close(payload_0: string)](https://github.com/toss/overlay-kit/assets/84632077/bf74e3cf-9c9a-45c9-8639-3eed2da0b6b5)
![overlay.closeAll(payload_0?: undefined)](https://github.com/toss/overlay-kit/assets/84632077/061cfb16-9002-47b9-81eb-a176df08d561)
![overlay_1](https://github.com/toss/overlay-kit/assets/84632077/6d556af4-b361-4a5b-a0c3-055f703ce7e2)

After:
![overlay.close(overlayId: string)](https://github.com/toss/overlay-kit/assets/84632077/99637347-97ea-46e4-994d-d7ab079baeed)
![overlay.closeAll()](https://github.com/toss/overlay-kit/assets/84632077/472e06c4-04f8-4008-b469-de7a61f086df)
![overlay_2](https://github.com/toss/overlay-kit/assets/84632077/d0d6670b-86a0-4d67-9012-dc32dffb5124)

Let me know if you have any comment on this issue :)