### PR TITLE
Chore: Align package name with folder name and update build script

### DIFF
--- a/examples/framer-motion/package.json
+++ b/examples/framer-motion/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@overlay-kit/playground",
+  "name": "@overlay-kit/framer-motion",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/examples/framer-motion/package.json
+++ b/examples/framer-motion/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "predev": "yarn workspace overlay-kit build",
+    "dev": "yarn predev && vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1049,9 +1049,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@overlay-kit/playground@workspace:examples/framer-motion":
+"@overlay-kit/framer-motion@workspace:examples/framer-motion":
   version: 0.0.0-use.local
-  resolution: "@overlay-kit/playground@workspace:examples/framer-motion"
+  resolution: "@overlay-kit/framer-motion@workspace:examples/framer-motion"
   dependencies:
     "@types/react": "npm:^18.2.0"
     "@types/react-dom": "npm:^18.2.0"


### PR DESCRIPTION
## What this PR solves

- [Change package name to equal folder name](https://github.com/toss/overlay-kit/commit/7d18874905724ad4a7847bc3e4cc1659121ffb81)
- [Change to run dev after build overay-kit](https://github.com/toss/overlay-kit/commit/3a06a117f5339269a63dac2b32c55d31cd92a6b7) 
  - this example relies on an overlay-kit, so change it to run after build