### PR TITLE
chore: edit `describe` in `event.test.tsx` and `create-use-external-events.ts`

### DIFF
--- a/packages/src/event.test.tsx
+++ b/packages/src/event.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { OverlayProvider } from './context/provider';
 import { overlay } from './event';
 
-describe('useOverlayContext는', () => {
+describe('overlay 객체는', () => {
   it('overlay.open을 통해 overlay를 그릴 수 있어야 한다.', () => {
     const wrapper = ({ children }: PropsWithChildren) => <OverlayProvider>{children}</OverlayProvider>;
 

--- a/packages/src/utils/create-use-external-events.test.ts
+++ b/packages/src/utils/create-use-external-events.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vitest } from 'vitest';
 import { createUseExternalEvents } from './create-use-external-events';
 
-describe('createCustomEvent는', () => {
+describe('createUseExternalEvents는', () => {
   it('이벤트를 생성할 수 있어야 합니다.', () => {
     type TestEvent = {
       event: () => void;


### PR DESCRIPTION
This PR fixes minor typo in `event.test.tsx` and `create-use-external-events.ts`.
The `describe` in `event.test.tsx` should have describe `overlay` object, not `useOverlayContext`. And same applies to `createUseExternalEvents`.