### PR TITLE
fix: fixed incorrect export from `index.ts`

### DIFF
--- a/packages/src/index.ts
+++ b/packages/src/index.ts
@@ -1,2 +1,2 @@
-export * from './event';
-export * from './context';
+export { overlay } from './event';
+export { OverlayProvider } from './context';


### PR DESCRIPTION
This PR restricts exports from `src/index.ts`. Previous codebase was exporting internal functions or hooks such as `createEvent`, `useOverlayList` or `useOverlayEvent`, which should not be accessible from outside of the module.

![스크린샷 2024-06-28 22 24 37](https://github.com/toss/overlay-kit/assets/84632077/de0374f4-4303-4117-9eb8-cf291dff6dab)
