### PR TITLE
refactor(overlay-kit): add type import ESLint rule

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -69,7 +69,12 @@ module.exports = tseslint.config(
       },
     },
     rules: {
-      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+          fixStyle: 'inline-type-imports',
+        },
+      ],
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-var-requires': 'warn',
       '@typescript-eslint/no-non-null-asserted-optional-chain': 'warn',
@@ -115,7 +120,6 @@ module.exports = tseslint.config(
             order: 'asc',
             caseInsensitive: false,
           },
-          'newlines-between': 'never',
         },
       ],
     },

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -69,6 +69,7 @@ module.exports = tseslint.config(
       },
     },
     rules: {
+      '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-var-requires': 'warn',
       '@typescript-eslint/no-non-null-asserted-optional-chain': 'warn',

--- a/examples/framer-motion/src/components/modal.tsx
+++ b/examples/framer-motion/src/components/modal.tsx
@@ -1,5 +1,5 @@
-import { AnimatePresence, Variants, motion } from 'framer-motion';
-import { PropsWithChildren, useRef } from 'react';
+import { AnimatePresence, motion, type Variants } from 'framer-motion';
+import { useRef, type PropsWithChildren } from 'react';
 
 type ModalProps = {
   isOpen?: boolean;

--- a/packages/src/context/context.ts
+++ b/packages/src/context/context.ts
@@ -1,4 +1,4 @@
-import { type FC } from 'react';
+import type { FC } from 'react';
 import { createSafeContext } from '../utils';
 
 export type OverlayControllerComponent = FC<OverlayControllerProps>;

--- a/packages/src/context/context.ts
+++ b/packages/src/context/context.ts
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import { type FC } from 'react';
 import { createSafeContext } from '../utils';
 
 export type OverlayControllerComponent = FC<OverlayControllerProps>;

--- a/packages/src/context/provider.tsx
+++ b/packages/src/context/provider.tsx
@@ -1,6 +1,6 @@
-import { type PropsWithChildren, useCallback, useReducer, useEffect, useRef } from 'react';
-import { type OverlayContextValue, OverlayContextProvider, OverlayControllerComponent } from './context';
-import { type OverlayReducerState, overlayReducer } from './reducer';
+import { useCallback, useEffect, useReducer, useRef, type PropsWithChildren } from 'react';
+import { OverlayContextProvider, type OverlayContextValue, type OverlayControllerComponent } from './context';
+import { overlayReducer, type OverlayReducerState } from './reducer';
 import { useOverlayEvent } from '../event';
 
 export function OverlayProvider({ children }: PropsWithChildren) {

--- a/packages/src/context/reducer.ts
+++ b/packages/src/context/reducer.ts
@@ -1,4 +1,4 @@
-import type { OverlayControllerComponent } from './context';
+import { type OverlayControllerComponent } from './context';
 
 export type OverlayItem = {
   id: string;

--- a/packages/src/event.ts
+++ b/packages/src/event.ts
@@ -1,4 +1,4 @@
-import { OverlayControllerComponent, type OverlayContextValue } from './context/context';
+import type { OverlayContextValue, OverlayControllerComponent } from './context/context';
 import { randomId } from './utils';
 import { createUseExternalEvents } from './utils/create-use-external-events';
 

--- a/packages/src/event.ts
+++ b/packages/src/event.ts
@@ -1,4 +1,4 @@
-import type { OverlayContextValue, OverlayControllerComponent } from './context/context';
+import { type OverlayContextValue, type OverlayControllerComponent } from './context/context';
 import { randomId } from './utils';
 import { createUseExternalEvents } from './utils/create-use-external-events';
 


### PR DESCRIPTION
"type import" is being used, but "human error" is visible. Complement by adding "ESLint" rule.

### consistent-type-imports rule
You can refer to [this link](https://typescript-eslint.io/rules/consistent-type-imports/).

![image](https://github.com/toss/overlay-kit/assets/55759551/f1255ae0-c091-4d49-850d-088639e5ac64)