### PR TITLE
refactor(overlay-kit): apply immer

### DIFF
--- a/packages/package.json
+++ b/packages/package.json
@@ -59,5 +59,8 @@
   "peerDependencies": {
     "react": "^18",
     "react-dom": "^18"
+  },
+  "dependencies": {
+    "immer": "^10.1.1"
   }
 }

--- a/packages/src/context/reducer.ts
+++ b/packages/src/context/reducer.ts
@@ -1,3 +1,4 @@
+import { produce, type Draft } from 'immer';
 import type { OverlayControllerComponent } from './context';
 
 export type OverlayItem = {
@@ -21,73 +22,44 @@ export type OverlayReducerAction =
   | { type: 'REMOVE_ALL' };
 
 export function overlayReducer(state: OverlayReducerState, action: OverlayReducerAction): OverlayReducerState {
-  switch (action.type) {
-    case 'ADD': {
-      return {
-        current: action.overlay.id,
-        overlayOrderList: [...state.overlayOrderList, action.overlay.id],
-        overlayData: {
-          ...state.overlayData,
-          [action.overlay.id]: action.overlay,
-        },
-      };
-    }
-    case 'OPEN': {
-      return {
-        ...state,
-        overlayData: {
-          ...state.overlayData,
-          [action.overlayId]: {
-            ...state.overlayData[action.overlayId],
-            isOpen: true,
-          },
-        },
-      };
-    }
-    case 'CLOSE': {
-      return {
-        ...state,
-        overlayData: {
-          ...state.overlayData,
-          [action.overlayId]: {
-            ...state.overlayData[action.overlayId],
-            isOpen: false,
-          },
-        },
-      };
-    }
-    case 'REMOVE': {
-      const remainingOverlays = state.overlayOrderList.filter((item) => item !== action.overlayId);
-      if (state.overlayOrderList.length === remainingOverlays.length) {
-        return state;
+  return produce(state, (draft: Draft<OverlayReducerState>) => {
+    switch (action.type) {
+      case 'ADD': {
+        draft.current = action.overlay.id;
+        draft.overlayOrderList.push(action.overlay.id);
+        draft.overlayData[action.overlay.id] = action.overlay;
+        break;
       }
+      case 'OPEN': {
+        draft.overlayData[action.overlayId].isOpen = true;
+        break;
+      }
+      case 'CLOSE': {
+        draft.overlayData[action.overlayId].isOpen = false;
+        break;
+      }
+      case 'REMOVE': {
+        const remainingOverlays = draft.overlayOrderList.filter((item) => item !== action.overlayId);
 
-      const copiedOverlayData = { ...state.overlayData };
-      delete copiedOverlayData[action.overlayId];
+        if (state.overlayOrderList.length === remainingOverlays.length) {
+          break;
+        }
 
-      return {
-        current: remainingOverlays.at(-1) || state.current,
-        overlayOrderList: remainingOverlays,
-        overlayData: copiedOverlayData,
-      };
+        draft.overlayOrderList = remainingOverlays;
+        delete draft.overlayData[action.overlayId];
+        draft.current = remainingOverlays.at(-1) || state.current;
+        break;
+      }
+      case 'CLOSE_ALL': {
+        Object.keys(draft.overlayData).forEach((key) => (draft.overlayData[key].isOpen = false));
+        break;
+      }
+      case 'REMOVE_ALL': {
+        draft.overlayOrderList = [];
+        draft.overlayData = {};
+        draft.current = state.current;
+        break;
+      }
     }
-    case 'CLOSE_ALL': {
-      return {
-        ...state,
-        overlayData: Object.keys(state.overlayData).reduce(
-          (prev, curr) => ({
-            ...prev,
-            [curr]: {
-              ...state.overlayData[curr],
-              isOpen: false,
-            } satisfies OverlayItem,
-          }),
-          {} satisfies Record<string, OverlayItem>
-        ),
-      };
-    }
-    case 'REMOVE_ALL': {
-      return { current: state.current, overlayOrderList: [], overlayData: {} };
-    }
-  }
+  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3858,6 +3858,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immer@npm:^10.1.1":
+  version: 10.1.1
+  resolution: "immer@npm:10.1.1"
+  checksum: 10c0/b749e10d137ccae91788f41bd57e9387f32ea6d6ea8fd7eb47b23fd7766681575efc7f86ceef7fe24c3bc9d61e38ff5d2f49c2663b2b0c056e280a4510923653
+  languageName: node
+  linkType: hard
+
 "import-fresh@npm:^3.2.1":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
@@ -4948,6 +4955,7 @@ __metadata:
     "@types/react": "npm:^18.2.0"
     "@types/react-dom": "npm:^18.2.0"
     "@vitejs/plugin-react": "npm:^4.3.0"
+    immer: "npm:^10.1.1"
     jsdom: "npm:^24.0.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"


### PR DESCRIPTION
I changed the code that was marked with "spread operator" to make it readable.

"Immer" improves not only readability but also maintenance. However, if immer is added to the overlay-kit that claims "Small Bundle Size", I am concerned about increasing the size.