### PR TITLE
docs: add custom-id sidebar

### DIFF
--- a/docs/.vitepress/en.mts
+++ b/docs/.vitepress/en.mts
@@ -23,6 +23,7 @@ export const en = defineConfig({
       {
         text: 'Usage',
         items: [
+          { text: 'Assignment Custom id', link: '/usage/custom-id' },
           { text: 'OverlayProvider', link: '/usage/overlay-provider' },
           { text: 'The overlay object', link: '/usage/overlay' },
         ],

--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -23,6 +23,7 @@ export const ko = defineConfig({
       {
         text: '사용법',
         items: [
+          { text: 'Custom id 지정하기', link: '/ko/usage/custom-id' },
           { text: 'OverlayProvider', link: '/ko/usage/overlay-provider' },
           { text: 'overlay 객체', link: '/ko/usage/overlay' },
         ],


### PR DESCRIPTION
I think the custom ID feature was added, but I couldn't find it in the documentation.
So I add sidebar link.

![스크린샷 2024-07-05 오후 12 18 55](https://github.com/toss/overlay-kit/assets/79239852/2d424aea-40ef-4bf3-a8db-e2adcff109cc)

![스크린샷 2024-07-05 오후 12 18 49](https://github.com/toss/overlay-kit/assets/79239852/51e1e553-7863-4d85-999e-a4552ce33bab)
