### PR TITLE
docs: typo at ko quickstart

### DIFF
--- a/docs/ko/quickstart.md
+++ b/docs/ko/quickstart.md
@@ -35,7 +35,8 @@ export default function App(props) {
 
 이제 overlay-kit으로 열리는 모든 오버레이는 `<Example />` 컴포넌트 옆에 렌더링될거예요.
 
-> [!IMPORTANT] > `<OverlayProvider />`는 React 애플리케이션 전체에서 1개만 렌더링해야 해요.
+> [!IMPORTANT]
+> `<OverlayProvider />`는 React 애플리케이션 전체에서 1개만 렌더링해야 해요.
 
 ## 오버레이 열기
 


### PR DESCRIPTION
I saw some typo at korean docs

## as is

![스크린샷 2024-07-05 오후 1 23 25](https://github.com/toss/overlay-kit/assets/26461307/db9ae7da-7756-45e6-8bd5-551f45e54a68)

eng ver is...

![스크린샷 2024-07-05 오후 1 23 51](https://github.com/toss/overlay-kit/assets/26461307/b4b0e56e-ddf8-49ee-9b77-d36b22a666e8)


## to be

![스크린샷 2024-07-05 오후 1 23 35](https://github.com/toss/overlay-kit/assets/26461307/daeeb8e3-e8f8-43d4-a5e2-91e85ef4652b)
