### PR TITLE
fix: Set current to null if no overlay remains on unmount

### DIFF
--- a/.changeset/soft-jokes-move.md
+++ b/.changeset/soft-jokes-move.md
@@ -1,0 +1,5 @@
+---
+'overlay-kit': patch
+---
+
+Set current to null if no overlay remains on unmount

--- a/packages/src/context/reducer.ts
+++ b/packages/src/context/reducer.ts
@@ -54,7 +54,7 @@ export function overlayReducer(state: OverlayData, action: OverlayReducerAction)
       delete copiedOverlayData[action.overlayId];
 
       return {
-        current: remainingOverlays.at(-1) || state.current,
+        current: remainingOverlays.at(-1) ?? null,
         overlayOrderList: remainingOverlays,
         overlayData: copiedOverlayData,
       };
@@ -75,7 +75,7 @@ export function overlayReducer(state: OverlayData, action: OverlayReducerAction)
       };
     }
     case 'REMOVE_ALL': {
-      return { current: state.current, overlayOrderList: [], overlayData: {} };
+      return { current: null, overlayOrderList: [], overlayData: {} };
     }
   }
 }


### PR DESCRIPTION
close: #37 