### PR TITLE
chore: rename to overlayId

### DIFF
--- a/.changeset/new-dodos-watch.md
+++ b/.changeset/new-dodos-watch.md
@@ -1,0 +1,5 @@
+---
+"overlay-kit": patch
+---
+
+chore: rename to overlayId

--- a/packages/src/event.ts
+++ b/packages/src/event.ts
@@ -20,11 +20,11 @@ function open(controller: OverlayControllerComponent, options?: OpenOverlayOptio
 
   return overlayId;
 }
-function close(id: string) {
-  dispatchOverlay({ type: 'CLOSE', overlayId: id });
+function close(overlayId: string) {
+  dispatchOverlay({ type: 'CLOSE', overlayId });
 }
-function unmount(id: string) {
-  dispatchOverlay({ type: 'REMOVE', overlayId: id });
+function unmount(overlayId: string) {
+  dispatchOverlay({ type: 'REMOVE', overlayId });
 }
 function closeAll() {
   dispatchOverlay({ type: 'CLOSE_ALL' });


### PR DESCRIPTION
close #38 

Rename it for consistency.

`id` => `overlayId`