### PR TITLE
test: add afterEach unmountAll()

### DIFF
--- a/packages/src/event.test.tsx
+++ b/packages/src/event.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import { act, useEffect, type PropsWithChildren } from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { OverlayProvider } from './context/provider';
 import { overlay } from './event';
+
+afterEach(() => {
+  overlay.unmountAll();
+});
 
 describe('overlay object', () => {
   it('should be able to close an open overlay using overlay.unmount', async () => {


### PR DESCRIPTION
When I tried to add test code, the old test dependencies were left behind 😂.

**event.test.tsx**

```tsx
  ... // Existing code
  // Test code to add
  it('test', () => {
    const wrapper = ({ children }: PropsWithChildren) => <OverlayProvider>{children}</OverlayProvider>;

    const Component = () => {
      const overlayData = useOverlayData();
      console.log(overlayData);

      return null;
    };

    const renderComponent = render(<Component />, { wrapper });
  });
```

To solve this, I added the following code

```tsx
 afterEach(() => {
   overlay.unmountAll();
 });
```