### PR TITLE
Fix: Update 'current' to Reflect Last Overlay When Closing Intermediate Overlays

### DIFF
--- a/.changeset/quiet-bobcats-pretend.md
+++ b/.changeset/quiet-bobcats-pretend.md
@@ -1,0 +1,8 @@
+---
+'overlay-kit': patch
+---
+
+Fix: Ensure 'current' reflects the last overlay when closing intermediate overlays
+
+- Resolve issue where 'current' does not update to the last overlay when closing an intermediate overlay
+- Add logic to correctly update 'current' in reducer

--- a/packages/src/context/reducer.ts
+++ b/packages/src/context/reducer.ts
@@ -33,12 +33,29 @@ export function overlayReducer(state: OverlayData, action: OverlayReducerAction)
       };
     }
     case 'CLOSE': {
-      const closedCurrentIndex = state.overlayOrderList.findIndex((item) => item === action.overlayId);
-      const current = state.overlayOrderList[closedCurrentIndex - 1] ?? null;
+      const openedOverlayOrderList = state.overlayOrderList.filter(
+        (orderedOverlayId) => state.overlayData[orderedOverlayId].isOpen === true
+      );
+      const targetIndexInOpenedList = openedOverlayOrderList.findIndex((item) => item === action.overlayId);
+
+      /**
+       * @description If closing the last overlay, specify the overlay before it.
+       * @description If closing intermediate overlays, specifies the last overlay.
+       *
+       * @example open - [1, 2, 3, 4]
+       * close 2 => current: 4
+       * close 4 => current: 3
+       * close 2 => current: 1
+       * close 1 => current: null
+       */
+      const currentOverlayId =
+        targetIndexInOpenedList === openedOverlayOrderList.length - 1
+          ? openedOverlayOrderList[targetIndexInOpenedList - 1] ?? null
+          : openedOverlayOrderList.at(-1) ?? null;
 
       return {
         ...state,
-        current,
+        current: currentOverlayId,
         overlayData: {
           ...state.overlayData,
           [action.overlayId]: {


### PR DESCRIPTION
### Description
This PR addresses an issue where the 'current' overlay does not update to the last overlay when an intermediate overlay is closed. This behavior can lead to inconsistencies in the UI state.

### Changes
- Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Added checks to handle cases where the overlay order is modified.

### Motivation and Context
The previous implementation did not account for scenarios where closing an intermediate overlay should update the 'current' overlay to reflect the last one in the order. This fix ensures that the 'current' overlay always points to the last opened overlay, maintaining consistent UI behavior.

### How Will This Be Tested?
- Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
- I plan to add unit tests to verify the reducer logic for maintaining the correct 'current' overlay.

### Related Issues
Fixes #44

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.