### PR TITLE
fix: state reset issue on overlay reopen

### DIFF
--- a/.changeset/tricky-grapes-bake.md
+++ b/.changeset/tricky-grapes-bake.md
@@ -1,0 +1,10 @@
+---
+"overlay-kit": patch
+---
+
+fix: state reset issue on overlay reopen
+
+This change fixes an issue where overlays did not retain their state when reopened without unmounting, even though they were not removed from the DOM.
+The overlayReducer has been updated to maintain the state of overlays between close and open cycles, addressing an unintended state reset.
+
+Related Issue: Fixes #57

--- a/packages/src/context/reducer.ts
+++ b/packages/src/context/reducer.ts
@@ -23,10 +23,12 @@ export function overlayReducer(state: OverlayData, action: OverlayReducerAction)
          * @description Brings the overlay to the front when reopened after closing without unmounting.
          */
         overlayOrderList: [...state.overlayOrderList.filter((item) => item !== action.overlay.id), action.overlay.id],
-        overlayData: {
-          ...state.overlayData,
-          [action.overlay.id]: action.overlay,
-        },
+        overlayData: isExisted
+          ? state.overlayData
+          : {
+              ...state.overlayData,
+              [action.overlay.id]: action.overlay,
+            },
       };
     }
     case 'OPEN': {


### PR DESCRIPTION
## Description
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

- Why is this change required?
- What problem does it solve?
- List any dependencies that are required for this change.
-->

This change fixes an issue where overlays did not retain their state when reopened without unmounting, even though they were not removed from the DOM. The overlayReducer has been updated to maintain the state of overlays between close and open cycles, addressing an unintended state reset.

**Related Issue:** Fixes #57 

## Changes
<!-- 
List the specific changes and modifications made in the codebase. Provide details on what was changed, added, or removed.
- Example: Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Example: Added checks to handle cases where the overlay order is modified.
-->

- Modified the overlayReducer to check if an overlay exists before updating its state in `overlayData`. If the overlay exists, its state is retained.
- Ensured that overlays do not reset their state upon reopening unless explicitly re-initialized or unmounted.

## Motivation and Context
<!-- 
Explain the context and background for the change. Why is this change necessary? What problem does it address?
-->

This change is necessary to ensure that the overlay components behave as expected across user interactions.

## How Has This Been Tested?
<!-- 
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
- Example: Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
- Example: Added unit tests to verify the reducer logic for maintaining the correct 'current' overlay.
-->

- Tested by manually reopening overlays without unmounting them to ensure their state is maintained.

## Screenshots (if appropriate):
<!-- (Insert screenshots here if relevant) -->

https://github.com/user-attachments/assets/f1933e46-3d1f-4902-86cc-b9e8eb097d4d

## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have performed a self-review of my own code.
- [ ] My code is commented, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further Comments
<!-- If there are any further comments or questions, please write them here. -->