### PR TITLE
feat: Add cleanup effect for unmounting

### DIFF
--- a/.changeset/brown-boxes-wink.md
+++ b/.changeset/brown-boxes-wink.md
@@ -1,0 +1,10 @@
+---
+"overlay-kit": patch
+---
+
+feat: Add cleanup effect for unmounting
+
+This commit introduces a useEffect cleanup function in the OverlayProvider component that dispatches a 'REMOVE_ALL' action when the component unmounts.
+This change ensures that all overlays are properly cleaned up during testing scenarios, preventing state leakage and side effects from persistent overlays.
+
+**Related Issue:** Fixes #63

--- a/packages/src/context/provider.tsx
+++ b/packages/src/context/provider.tsx
@@ -7,6 +7,12 @@ import { overlay } from '../event';
 export function OverlayProvider({ children }: PropsWithChildren) {
   const overlayState = useSyncOverlayStore();
 
+  useEffect(() => {
+    return () => {
+      dispatchOverlay({ type: 'REMOVE_ALL' });
+    };
+  }, []);
+
   return (
     <OverlayContextProvider value={overlayState}>
       {children}


### PR DESCRIPTION
This commit adds a useEffect cleanup function to the OverlayProvider component that dispatches a ‘REMOVE_ALL’ action upon unmounting. This ensures that overlays are properly cleaned up during testing scenarios, preventing state leakage and side effects from persistent overlays.

## Description
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

- Why is this change required?
- What problem does it solve?
- List any dependencies that are required for this change.
-->

This commit introduces a useEffect cleanup function in the OverlayProvider component that dispatches a 'REMOVE_ALL' action when the component unmounts.
This change ensures that all overlays are properly cleaned up during testing scenarios, preventing state leakage and side effects from persistent overlays.

**Related Issue:** Fixes #63

## Changes
<!-- 
List the specific changes and modifications made in the codebase. Provide details on what was changed, added, or removed.
- Example: Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Example: Added checks to handle cases where the overlay order is modified.
-->

- Added a useEffect cleanup function in `OverlayProvider` to dispatch 'REMOVE_ALL' on unmount.

## Motivation and Context
<!-- 
Explain the context and background for the change. Why is this change necessary? What problem does it address?
-->

This change is necessary to enhance the testability of the OverlayProvider by ensuring overlays do not persist state across tests, which can lead to unpredictable behavior and flaky tests.

## How Has This Been Tested?
<!-- 
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
- Example: Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
- Example: Added unit tests to verify the reducer logic for maintaining the correct 'current' overlay.
-->

## Screenshots (if appropriate):
<!-- (Insert screenshots here if relevant) -->

## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have performed a self-review of my own code.
- [ ] My code is commented, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further Comments
<!-- If there are any further comments or questions, please write them here. -->