### PR TITLE
refactor: Migrate overlay-kit test code act to userEvent

### DIFF
--- a/packages/package.json
+++ b/packages/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^15.0.5",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.3.0",

--- a/packages/package.json
+++ b/packages/package.json
@@ -46,6 +46,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.3.2",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^15.0.5",
     "@testing-library/user-event": "^14.5.2",

--- a/packages/src/event.test.tsx
+++ b/packages/src/event.test.tsx
@@ -5,15 +5,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { OverlayProvider } from './context/provider';
 import { overlay } from './event';
 
-/**
- *
- * @description This is a wrapper component that provides the OverlayProvider context to the children components.
- */
 const wrapper = ({ children }: PropsWithChildren) => <OverlayProvider>{children}</OverlayProvider>;
 
 /**
  *
- * @description utility function by render and userEvent.setup
+ * @description Utility functions to perform render and userEvent.setup
  */
 const renderWithUser = <T extends JSX.Element>(Component: T, options?: Parameters<typeof render>[1]) => {
   const user = userEvent.setup();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1534,6 +1534,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^10.3.2":
+  version: 10.3.2
+  resolution: "@testing-library/dom@npm:10.3.2"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/aria-query": "npm:^5.0.1"
+    aria-query: "npm:5.3.0"
+    chalk: "npm:^4.1.0"
+    dom-accessibility-api: "npm:^0.5.9"
+    lz-string: "npm:^1.5.0"
+    pretty-format: "npm:^27.0.2"
+  checksum: 10c0/3078b3253a73136169d897179bfc5e2073025f317573c9fd95d526df9a875a3ec3e9243377d93d23b7e40fadf60dd51517a15bf83b8f521a68b410b350df39e9
+  languageName: node
+  linkType: hard
+
 "@testing-library/jest-dom@npm:^6.4.2":
   version: 6.4.5
   resolution: "@testing-library/jest-dom@npm:6.4.5"
@@ -1582,6 +1598,15 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/ac8ee8968e81949ecb35f7ee34741c2c043f73dd7fee2247d56f6de6a30de4742af94f25264356863974e54387485b46c9448ecf3f6ca41cf4339011c369f2d4
+  languageName: node
+  linkType: hard
+
+"@testing-library/user-event@npm:^14.5.2":
+  version: 14.5.2
+  resolution: "@testing-library/user-event@npm:14.5.2"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 10c0/68a0c2aa28a3c8e6eb05cafee29705438d7d8a9427423ce5064d44f19c29e89b5636de46dd2f28620fb10abba75c67130185bbc3aa23ac1163a227a5f36641e1
   languageName: node
   linkType: hard
 
@@ -5522,8 +5547,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "overlay-kit@workspace:packages"
   dependencies:
+    "@testing-library/dom": "npm:^10.3.2"
     "@testing-library/jest-dom": "npm:^6.4.2"
     "@testing-library/react": "npm:^15.0.5"
+    "@testing-library/user-event": "npm:^14.5.2"
     "@types/react": "npm:^18.2.0"
     "@types/react-dom": "npm:^18.2.0"
     "@vitejs/plugin-react": "npm:^4.3.0"


### PR DESCRIPTION
## Description
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

- Why is this change required?
- What problem does it solve?
- List any dependencies that are required for this change.
-->

Perform the migration to userEvent described in issue number 68.

**Related Issue:** Fixes #68

## Changes
<!-- 
List the specific changes and modifications made in the codebase. Provide details on what was changed, added, or removed.
- Example: Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Example: Added checks to handle cases where the overlay order is modified.
-->


- All changes occurred only in testcode

- add devDependencies @testing-library/user-event , @testing-library/dom

before

```tsx
    const renderComponent = render(<Component />, { wrapper });
    const testContentElement = await renderComponent.findByText(testContent);

    act(() => {
      testContentElement.click();
    });

    const dialogContentElement = await renderComponent.findByText(dialogContent);

    act(() => {
      dialogContentElement.click();
    });
    await waitFor(() => {
      expect(mockFn).toHaveBeenCalledWith(true);
    });
```

after

```tsx
    const { user } = renderWithUser(<Component />);

    await user.click(await screen.findByRole('button', { name: overlayTriggerContent }));

    await user.click(await screen.findByRole('button', { name: overlayDialogContent }));

    await waitFor(() => {
      expect(mockFn).toHaveBeenCalledWith(true);
    });
```


## Motivation and Context
<!-- 
Explain the context and background for the change. Why is this change necessary? What problem does it address?
-->

- By using userEvent, you will be able to write test code in a form that is more similar to the user's actual use cases.

- The more your tests resemble the way your software is used, the more confidence they can give you.

- All test cases currently used in "overlay-kit" can be migrated to userEvent without any problems.

## How Has This Been Tested?
<!-- 
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
- Example: Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
- Example: Added unit tests to verify the reducer logic for maintaining the correct 'current' overlay.
-->

Manually checked whether the test code passed or not

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have performed a self-review of my own code.
- [x] My code is commented, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further Comments
<!-- If there are any further comments or questions, please write them here. -->

Added utility functions for testing to reduce boilerplate

I think these utility functions are useful, but my concern is that they may actually add complexity.

What do you think?

```tsx
/**
 *
 * @description Utility functions to perform render and userEvent.setup
 */
const renderWithUser = <T extends JSX.Element>(Component: T, options?: Parameters<typeof render>[1]) => {
  const user = userEvent.setup();
  return { ...render(Component, { wrapper, ...options }), user };
};

const { user } = renderWithUser(<Component />);
```

If there is anything else that needs correction, please let me know at any time. 

thank you