### PR TITLE
chore(eslint.config.cjs): replace eslint-config-prettier with eslint-plugin-prettier

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -2,8 +2,8 @@
 
 const eslint = require('@eslint/js');
 const tseslint = require('typescript-eslint');
-const prettierConfig = require('eslint-config-prettier');
 const importPlugin = require('eslint-plugin-import');
+const eslintPluginPrettierRecommended = require('eslint-plugin-prettier/recommended');
 const unicorn = require('eslint-plugin-unicorn');
 const unusedImports = require('eslint-plugin-unused-imports');
 
@@ -12,7 +12,6 @@ module.exports = tseslint.config(
     ignores: ['**/.vitepress/', '**/dist/', '**/esm/', '**/.next/', '**/.next-local/', '.pnp.*', '.yarn/'],
   },
   eslint.configs.recommended,
-  prettierConfig,
   {
     plugins: { unicorn },
     rules: {
@@ -123,5 +122,6 @@ module.exports = tseslint.config(
         },
       ],
     },
-  }
+  },
+  eslintPluginPrettierRecommended
 );


### PR DESCRIPTION
## Description
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

- Why is this change required?
- What problem does it solve?
- List any dependencies that are required for this change.
-->

this pr removes the usage of `eslint-config-prettier` from `eslint.config.cjs` and adds `eslint-plugin-prettier`.
the `eslint-config-prettier` library itself is not deleted, as it is required for `eslint-plugin-prettier` to function correctly.

### why is this necessary?

  * `eslint-config-prettier` disables eslint rules that conflict with prettier.
  * `eslint-plugin-prettier` enforces prettier rules within eslint, providing a seamless integration. however, it depends on `eslint-config-prettier` to handle conflict resolution.

### how does it solve the problem?

  * `eslint-config-prettier` remains as a dependency, ensuring compatibility.
  * `eslint-plugin-prettier` is added to integrate prettier rules directly into eslint, improving developer experience.
  
## Changes
<!-- 
List the specific changes and modifications made in the codebase. Provide details on what was changed, added, or removed.
- Example: Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Example: Added checks to handle cases where the overlay order is modified.
-->

* removed `eslint-config-prettier` usage from `eslint.config.cjs`
* added `eslint-plugin-prettier` to `eslint.config.cjs`

## Motivation and Context
<!-- 
Explain the context and background for the change. Why is this change necessary? What problem does it address?
-->

### why this change is necessary

* better integration of prettier with eslint
  * `eslint-plugin-prettier` uses prettier rules as eslint rules, making them easier to enforce and validate during development.
* resolve potential conflicts
  * while `eslint-plugin-prettier` enforces prettier rules, it requires `eslint-config-prettier` to handle conflicting eslint rules, ensuring compatibility.
* improve developer experience
  * developers can use a unified linting and formatting workflow with eslint and prettier integrated through `eslint-plugin-prettier`.

## How Has This Been Tested?
<!-- 
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
- Example: Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
- Example: Added unit tests to verify the reducer logic for maintaining the correct 'current' overlay.
-->

### test scenarios

  * verified that prettier rules are correctly applied through `eslint-plugin-prettier`.
  * ensured there are no conflicts between eslint and prettier settings.

### test results

  * `eslint-plugin-prettier` successfully applied prettier rules based on `.prettierrc`.
  * the workflow remained stable with no issues or regressions.

## Screenshots (if appropriate):
<!-- (Insert screenshots here if relevant) -->

### before

![image](https://github.com/user-attachments/assets/ca8e7fb0-ecfa-4376-b4c8-5ebada687d48)

### after

![image](https://github.com/user-attachments/assets/a18f6436-9533-4197-ba3e-0e69e6f387b6)


## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have performed a self-review of my own code.
- [ ] My code is commented, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further Comments
<!-- If there are any further comments or questions, please write them here. -->