### PR TITLE
fix: initializing current overlay after close all overlays

### DIFF
--- a/.changeset/stupid-boxes-pay.md
+++ b/.changeset/stupid-boxes-pay.md
@@ -1,0 +1,5 @@
+---
+"overlay-kit": patch
+---
+
+fix: initializing current overlay after close all overlays

--- a/packages/src/context/reducer.ts
+++ b/packages/src/context/reducer.ts
@@ -114,6 +114,7 @@ export function overlayReducer(state: OverlayData, action: OverlayReducerAction)
     case 'CLOSE_ALL': {
       return {
         ...state,
+        current: null,
         overlayData: Object.keys(state.overlayData).reduce(
           (prev, curr) => ({
             ...prev,

--- a/packages/src/event.test.tsx
+++ b/packages/src/event.test.tsx
@@ -288,6 +288,39 @@ describe('overlay object', () => {
     });
   });
 
+  it('should not be able to get current overlay when all overlays are closed', async () => {
+    const contents = {
+      first: 'overlay-content-1',
+      second: 'overlay-content-2',
+    };
+
+    function Component() {
+      const current = useCurrentOverlay();
+
+      useEffect(() => {
+        // Open 2 overlays sequentially
+        overlay.open(({ isOpen }) => isOpen && <div data-testid="overlay-1">{contents.first}</div>);
+        overlay.open(({ isOpen }) => isOpen && <div data-testid="overlay-2">{contents.second}</div>);
+      }, []);
+
+      return <div data-testid="current-overlay">{current}</div>;
+    }
+
+    render(<Component />, { wrapper });
+
+    // Wait for all overlays to be mounted
+    await waitFor(() => {
+      expect(screen.getByTestId('overlay-1')).toBeInTheDocument();
+      expect(screen.getByTestId('overlay-2')).toBeInTheDocument();
+    });
+
+    // close all overlays
+    overlay.closeAll();
+    await waitFor(() => {
+      expect(screen.getByTestId('current-overlay')).toHaveTextContent('');
+    });
+  });
+
   it('should be able to unmount all overlays', async () => {
     const contents = {
       first: 'overlay-content-1',


### PR DESCRIPTION
## Description
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

- Why is this change required?
- What problem does it solve?
- List any dependencies that are required for this change.
-->

**Related Issue:** Fixes N/A

## Changes
<!-- 
List the specific changes and modifications made in the codebase. Provide details on what was changed, added, or removed.
- Example: Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Example: Added checks to handle cases where the overlay order is modified.
-->
- Set `current=null` after close all overlays.

## Motivation and Context
<!-- 
Explain the context and background for the change. Why is this change necessary? What problem does it address?
-->
- useCurrentOverlay could retrieve last `current overlay` even after `overlay.closeAll();` is called.

## How Has This Been Tested?
<!-- 
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
- Example: Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
- Example: Added unit tests to verify the reducer logic for maintaining the correct 'current' overlay.
-->
- Added a unit test to verify if current is unreachable after `overlay.closeAll()` is called.

## Screenshots (if appropriate):
<!-- (Insert screenshots here if relevant) -->

## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have performed a self-review of my own code.
- [x] My code is commented, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Further Comments
<!-- If there are any further comments or questions, please write them here. -->