### PR TITLE
fix: Enhance overlay reducer state management

### DIFF
--- a/.changeset/evil-donuts-fold.md
+++ b/.changeset/evil-donuts-fold.md
@@ -1,0 +1,5 @@
+---
+'overlay-kit': patch
+---
+
+fix: Enhance overlay reducer state management

--- a/packages/src/context/provider/content-overlay-controller.tsx
+++ b/packages/src/context/provider/content-overlay-controller.tsx
@@ -39,7 +39,7 @@ export function ContentOverlayController({
   /**
    * @description Executes when closing and reopening an overlay without unmounting.
    */
-  if (prevCurrent.current !== current && isOpen === false) {
+  if (prevCurrent.current !== current) {
     prevCurrent.current = current;
 
     if (current === overlayId) {

--- a/packages/src/context/reducer.ts
+++ b/packages/src/context/reducer.ts
@@ -41,7 +41,6 @@ export function overlayReducer(state: OverlayData, action: OverlayReducerAction)
 
       return {
         ...state,
-        current: action.overlayId,
         overlayData: {
           ...state.overlayData,
           [action.overlayId]: {

--- a/packages/src/context/reducer.ts
+++ b/packages/src/context/reducer.ts
@@ -32,18 +32,33 @@ export function overlayReducer(state: OverlayData, action: OverlayReducerAction)
       };
     }
     case 'OPEN': {
+      const overlay = state.overlayData[action.overlayId];
+
+      // ignore if the overlay don't exist or already open
+      if (overlay == null || overlay.isOpen) {
+        return state;
+      }
+
       return {
         ...state,
+        current: action.overlayId,
         overlayData: {
           ...state.overlayData,
           [action.overlayId]: {
-            ...state.overlayData[action.overlayId],
+            ...overlay,
             isOpen: true,
           },
         },
       };
     }
     case 'CLOSE': {
+      const overlay = state.overlayData[action.overlayId];
+
+      // ignore if the overlay don't exist or already closed
+      if (overlay == null || !overlay.isOpen) {
+        return state;
+      }
+
       const openedOverlayOrderList = state.overlayOrderList.filter(
         (orderedOverlayId) => state.overlayData[orderedOverlayId].isOpen === true
       );
@@ -77,6 +92,13 @@ export function overlayReducer(state: OverlayData, action: OverlayReducerAction)
       };
     }
     case 'REMOVE': {
+      const overlay = state.overlayData[action.overlayId];
+
+      // ignore if the overlay don't exist
+      if (overlay == null) {
+        return state;
+      }
+
       const remainingOverlays = state.overlayOrderList.filter((item) => item !== action.overlayId);
       if (state.overlayOrderList.length === remainingOverlays.length) {
         return state;
@@ -112,8 +134,14 @@ export function overlayReducer(state: OverlayData, action: OverlayReducerAction)
       };
     }
     case 'CLOSE_ALL': {
+      // ignore if there is no overlay
+      if (Object.keys(state.overlayData).length === 0) {
+        return state;
+      }
+
       return {
         ...state,
+        current: null,
         overlayData: Object.keys(state.overlayData).reduce(
           (prev, curr) => ({
             ...prev,


### PR DESCRIPTION
## Description
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

- Why is this change required?
- What problem does it solve?
- List any dependencies that are required for this change.
-->

**Related Issue:** Fixes N/A

## Changes
<!-- 
List the specific changes and modifications made in the codebase. Provide details on what was changed, added, or removed.
- Example: Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Example: Added checks to handle cases where the overlay order is modified.
-->
- Add checks to prevent unnecessary state updates for non-existent or already open/closed overlays
- Handle edge cases like closing all overlays when no overlays exist
- Defence logic moved into reducer, thus I removed `isOpen === false` clause from `ContentOverlayController`

## Motivation and Context
<!-- 
Explain the context and background for the change. Why is this change necessary? What problem does it address?
-->

## How Has This Been Tested?
<!-- 
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
- Example: Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
- Example: Added unit tests to verify the reducer logic for maintaining the correct 'current' overlay.
-->
- Tested manually to ensure it works the same as before

## Screenshots (if appropriate):
<!-- (Insert screenshots here if relevant) -->

## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have performed a self-review of my own code.
- [x] My code is commented, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Further Comments
<!-- If there are any further comments or questions, please write them here. -->