### PR TITLE
fix: remove console log on dispatchOverlay

### DIFF
--- a/.changeset/strong-spoons-grin.md
+++ b/.changeset/strong-spoons-grin.md
@@ -1,0 +1,5 @@
+---
+"overlay-kit": patch
+---
+
+fix: remove console log on dispatchOverlay

--- a/packages/src/context/store.ts
+++ b/packages/src/context/store.ts
@@ -47,7 +47,6 @@ export function createRegisterOverlaysStore() {
 
   function dispatchOverlay(action: OverlayReducerAction) {
     overlays = overlayReducer(overlays, action);
-    console.log('test:: dispatchOverlay After', action, overlays);
     emitChangeListener();
   }
 


### PR DESCRIPTION
## Description

**Related Issue:** Fixes N/A

## Changes

Removed `console.log` statements used for debugging purposes.

## Motivation and Context

## How Has This Been Tested?

Tested manually to ensure that no console logs appear in the console

## Screenshots (if appropriate):

Console log discovered when using overlay-kit
<img width="851" alt="스크린샷 2025-02-20 13 56 44" src="https://github.com/user-attachments/assets/7ac167fc-a20c-4272-898e-2a5c7caecd81" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have performed a self-review of my own code.
- [x] My code is commented, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Further Comments
