### PR TITLE
fix: Change useState<boolean>() to useState(false) for clearer initialization

### DIFF
--- a/docs/src/pages/en/docs/guides/introduction.mdx
+++ b/docs/src/pages/en/docs/guides/introduction.mdx
@@ -167,7 +167,7 @@ import Button from '@mui/material/Button';
 import { ConfirmDialog } from './confirm-dialog';
 
 function App() {
-  const [result, setResult] = useState<boolean>();
+  const [result, setResult] = useState(false);
 
   return (
     <>

--- a/docs/src/pages/en/docs/more/basic.mdx
+++ b/docs/src/pages/en/docs/more/basic.mdx
@@ -71,7 +71,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 
 function App() {
-  const [result, setResult] = useState<boolean>();
+  const [result, setResult] = useState(false);
 
   return (
     <div>

--- a/docs/src/pages/ko/docs/guides/introduction.mdx
+++ b/docs/src/pages/ko/docs/guides/introduction.mdx
@@ -167,7 +167,7 @@ import Button from '@mui/material/Button';
 import { ConfirmDialog } from './confirm-dialog';
 
 function App() {
-  const [result, setResult] = useState<boolean>();
+  const [result, setResult] = useState(false);
 
   return (
     <>

--- a/docs/src/pages/ko/docs/more/basic.mdx
+++ b/docs/src/pages/ko/docs/more/basic.mdx
@@ -71,7 +71,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 
 function App() {
-  const [result, setResult] = useState<boolean>();
+  const [result, setResult] = useState(false);
 
   return (
     <div>


### PR DESCRIPTION
## Description

The current useState() can have an initial value of undefined, which could lead to unintended behavior. If a boolean type is intended, explicitly setting false as the default value is safer. This change also ensures consistency across the code, and as shown in the screenshot, the UI explicitly indicates that the initial value is false, so it makes sense to reflect this in the code by setting false as the initial value.


**Related Issue:** Fixes #136 

## Changes
- Updated all instances of useState<boolean>() to useState(false) for better clarity and consistency.

- Removed unnecessary type annotation <boolean> since TypeScript infers the type automatically when false is passed.

## Motivation and Context

The main motivation for this change is to ensure that the initial state of useState is explicitly set to a boolean value (false) rather than undefined. Additionally, this change aligns with other parts of the code (such as think-in-overlay-kit.mdx), ensuring consistency and readability.


## How Has This Been Tested?

I have modified the code in the local environment and confirmed that there are no issues.


## Screenshots (if appropriate):

### before

![image](https://github.com/user-attachments/assets/dfa71eb8-68fa-421b-b9cb-187308e21c8e)


### after

![image](https://github.com/user-attachments/assets/8f2be336-3283-4ba6-9554-2535ac254274)


## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] My code is commented, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

