### PR TITLE
Docs: add guides for `overlay-kit` installation

### DIFF
--- a/docs/src/pages/en/docs/guides/introduction.mdx
+++ b/docs/src/pages/en/docs/guides/introduction.mdx
@@ -6,6 +6,12 @@ import { Sandpack } from '@/components';
 
 You can efficiently implement overlays without complex state management or unnecessary event handling.
 
+## Installation
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit
+```
+
 ## Key Features
 
 ### Declarative API

--- a/docs/src/pages/ko/docs/guides/introduction.mdx
+++ b/docs/src/pages/ko/docs/guides/introduction.mdx
@@ -6,6 +6,12 @@ import { Sandpack } from '@/components';
 
 복잡한 상태 관리나 불필요한 이벤트 핸들링 없이, 효율적으로 오버레이를 구현할 수 있어요.
 
+## 설치하기
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit
+```
+
 ## 기능 모아보기
 
 ### 선언적 API


### PR DESCRIPTION
<h2 id="description">Description</h2>
I noticed that the installation method is only documented in the README file of the repository. I thought adding installation guidelines for `overlay-kit` at the beginning of the documentation would be a nice touch. :)

## Changes
- Added installation guide to `ko/guides/getting-started` and `en/guides/getting-started`

## Motivation and Context
<a href="#description">Description above</a> explains my motivation.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
<img width="1473" alt="image" src="https://github.com/user-attachments/assets/4ff59023-88c8-4397-bec7-df42cc700a52" />

## Types of changes
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [x] Documentation update

## Checklist
 - [x] I have performed a self-review of my own code.
 - [x] My code is commented, particularly in hard-to-understand areas.
 - [x] I have made corresponding changes to the documentation.
 - [x] My changes generate no new warnings.
 - [x] I have added tests that prove my fix is effective or that my feature works.
 - [x] New and existing unit tests pass locally with my changes.
 - [x] Any dependent changes have been merged and published in downstream modules.

## Further Comments
N/A