### PR TITLE
fix: tri-state pattern (including "not selected") in official usage of overlay.openAsync

### DIFF
--- a/docs/src/pages/en/docs/guides/introduction.mdx
+++ b/docs/src/pages/en/docs/guides/introduction.mdx
@@ -173,11 +173,11 @@ import Button from '@mui/material/Button';
 import { ConfirmDialog } from './confirm-dialog';
 
 function App() {
-  const [result, setResult] = useState<boolean>();
+  const [result, setResult] = useState<boolean | null>(null);
 
   return (
     <>
-      <p>result: {result ? 'Y' : 'N'}</p>
+      <p>{result === null ? 'Not selected' : result ? 'Y' : 'N'}</p>
       <Button
         onClick={async () => {
           const result = await overlay.openAsync(({ isOpen, close }) => {

--- a/docs/src/pages/ko/docs/guides/introduction.mdx
+++ b/docs/src/pages/ko/docs/guides/introduction.mdx
@@ -173,11 +173,11 @@ import Button from '@mui/material/Button';
 import { ConfirmDialog } from './confirm-dialog';
 
 function App() {
-  const [result, setResult] = useState<boolean>();
+  const [result, setResult] = useState<boolean | null>(null);
 
   return (
     <>
-      <p>result: {result ? 'Y' : 'N'}</p>
+      <p>{result === null ? "Not selected" : result ? "Y" : "N"}</p>
       <Button
         onClick={async () => {
           const result = await overlay.openAsync(({ isOpen, close }) => {


### PR DESCRIPTION
## Description
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

- Why is this change required?
- What problem does it solve?
- List any dependencies that are required for this change.
-->
This PR updates the usage example of overlay.openAsync to include a tri-state pattern: true, false, and null (representing “not selected”).
**Related Issue:** Fixes #142 
## Changes
<!-- 
List the specific changes and modifications made in the codebase. Provide details on what was changed, added, or removed.
- Example: Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Example: Added checks to handle cases where the overlay order is modified.
-->
- Updated example code to initialize the result state as null instead of false

- Modified the UI to display "Not selected" when result is null

- Improved clarity in differentiating between:
  - User confirming (true)

  - User canceling (false)

  - User not having selected anything yet (null)

## Motivation and Context
<!-- 
Explain the context and background for the change. Why is this change necessary? What problem does it address?
-->
The current example initializes the result as false, which causes the UI to display "N" even when the user hasn't made any selection yet. This leads to ambiguity in interpreting the user's intent.

By introducing an initial null state and displaying "Not selected" accordingly, this change improves UX clarity and demonstrates a more flexible usage pattern of overlay.openAsync.

## How Has This Been Tested?
<!-- 
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
- Example: Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
- Example: Added unit tests to verify the reducer logic for maintaining the correct 'current' overlay.
-->
Manually tested the updated example:

Before making any selection → "Not selected" is shown

After clicking "Yes" → "Y" is shown

After clicking "No" → "N" is shown

Confirmed that the UI correctly reflects the three distinct states

## Screenshots (if appropriate):
<!-- (Insert screenshots here if relevant) -->

https://github.com/user-attachments/assets/063c3bd4-d94d-47cb-a662-efb2279c1b1a



## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have performed a self-review of my own code.
- [x] My code is commented, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further Comments
<!-- If there are any further comments or questions, please write them here. -->
Happy to adjust based on feedback!