### PR TITLE
fix: remove unnecessary type assertion from Context.Provider

### DIFF
--- a/.changeset/early-ducks-hang.md
+++ b/.changeset/early-ducks-hang.md
@@ -1,0 +1,5 @@
+---
+"overlay-kit": patch
+---
+
+fix: remove unnecessary type assertion from Context.Provider

--- a/packages/src/utils/create-safe-context.ts
+++ b/packages/src/utils/create-safe-context.ts
@@ -22,5 +22,5 @@ export function createSafeContext<T>(displayName?: string): CreateContextReturn<
     return context;
   }
 
-  return [Context.Provider as Provider<T>, useSafeContext];
+  return [Context.Provider, useSafeContext];
 }


### PR DESCRIPTION
## Description

This pull request addresses the unnecessary type casting in the createSafeContext function. The Context.Provider is already correctly typed as T | typeof NullSymbol, so casting it to Provider<T> is redundant and unnecessary. This change improves code readability and maintains type safety without unnecessary type assertions.

## Changes

- Removed the unnecessary type casting of Context.Provider to Provider<T> in the createSafeContext function.

- Simplified the type declaration to ensure the code is cleaner and easier t

## Motivation and Context

This change was made to improve the maintainability of the code. By removing unnecessary type casting, we reduce complexity and make the codebase easier to understand. It's a best practice to avoid redundant type assertions, as they can lead to confusion and errors in the long run.


## How Has This Been Tested?

The changes have been manually tested to ensure that the context provider and consumer still function correctly. No functional changes were expected from this update, so existing tests related to context usage were sufficient.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [ ] I have performed a self-review of my own code.
- [ ] My code is commented, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

