### PR TITLE
feat: Add component key

### DIFF
--- a/.changeset/lazy-beds-brush.md
+++ b/.changeset/lazy-beds-brush.md
@@ -1,0 +1,10 @@
+---
+"overlay-kit": patch
+---
+
+feat: Add component key
+
+Fixed an issue with overlay components not properly remounting when unmounted and immediately reopened with the same ID.
+Added a new `componentKey` property that's separate from `overlayId` to ensure React properly handles component lifecycle. Each time `overlay.open()` is called, a new random `componentKey` is generated internally even when reusing the same `overlayId`.
+
+This fix resolves scenarios where calling `unmount()` followed by `open()` with the same overlay ID in quick succession would result in the overlay not being visible to users.

--- a/packages/src/context/provider/index.tsx
+++ b/packages/src/context/provider/index.tsx
@@ -15,11 +15,12 @@ export function createOverlayProvider() {
       overlayData: {},
     });
 
-    const open: OverlayEvent['open'] = useCallback(({ controller, overlayId }) => {
+    const open: OverlayEvent['open'] = useCallback(({ controller, overlayId, componentKey }) => {
       overlayDispatch({
         type: 'ADD',
         overlay: {
           id: overlayId,
+          componentKey,
           isOpen: false,
           controller: controller,
         },
@@ -50,11 +51,16 @@ export function createOverlayProvider() {
       <OverlayContextProvider value={overlayState}>
         {children}
         {overlayState.overlayOrderList.map((item) => {
-          const { id: currentOverlayId, isOpen, controller: currentController } = overlayState.overlayData[item];
+          const {
+            id: currentOverlayId,
+            componentKey,
+            isOpen,
+            controller: currentController,
+          } = overlayState.overlayData[item];
 
           return (
             <ContentOverlayController
-              key={currentOverlayId}
+              key={componentKey}
               isOpen={isOpen}
               current={overlayState.current}
               overlayId={currentOverlayId}

--- a/packages/src/context/reducer.ts
+++ b/packages/src/context/reducer.ts
@@ -2,7 +2,15 @@ import { type OverlayControllerComponent } from './provider/content-overlay-cont
 
 type OverlayId = string;
 type OverlayItem = {
+  /**
+   * @description The unique identifier for the overlay.
+   */
   id: OverlayId;
+  /**
+   * @description The key for the overlay component.
+   * This is used to identify the overlay component when it is unmounted.
+   */
+  componentKey: string;
   isOpen: boolean;
   controller: OverlayControllerComponent;
 };

--- a/packages/src/event.ts
+++ b/packages/src/event.ts
@@ -6,7 +6,7 @@ import { createUseExternalEvents } from './utils';
 import { randomId } from './utils/random-id';
 
 export type OverlayEvent = {
-  open: (args: { controller: OverlayControllerComponent; overlayId: string }) => void;
+  open: (args: { controller: OverlayControllerComponent; overlayId: string; componentKey: string }) => void;
   close: (overlayId: string) => void;
   unmount: (overlayId: string) => void;
   closeAll: () => void;
@@ -22,9 +22,10 @@ export function createOverlay() {
 
   const open = (controller: OverlayControllerComponent, options?: OpenOverlayOptions) => {
     const overlayId = options?.overlayId ?? randomId();
+    const componentKey = randomId();
     const dispatchOpenEvent = createEvent('open');
 
-    dispatchOpenEvent({ controller, overlayId });
+    dispatchOpenEvent({ controller, overlayId, componentKey });
     return overlayId;
   };
 


### PR DESCRIPTION
## Description
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

- Why is this change required?
- What problem does it solve?
- List any dependencies that are required for this change.
-->

**Related Issue:** Fixes # (issue_number)

## Changes
<!-- 
List the specific changes and modifications made in the codebase. Provide details on what was changed, added, or removed.
- Example: Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Example: Added checks to handle cases where the overlay order is modified.
-->

- Added `componentKey` property to overlay components
- Added `componentKey` parameter to the `open` event
- Changed the `key` value in `ContentOverlayController` from `overlayId` to `componentKey`
- Added `componentKey` field with related JSDoc comments to the `OverlayItem` type

## Motivation and Context
<!-- 
Explain the context and background for the change. Why is this change necessary? What problem does it address?
-->

Improved component lifecycle management by separating the overlay's unique identifier (overlayId) from the React component's key value.

Previously, when the same overlayId was reused, components weren't properly remounted. Now, componentKey is always generated as a new random value, ensuring correct mount/unmount cycles for components.


## How Has This Been Tested?
<!-- 
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
- Example: Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
- Example: Added unit tests to verify the reducer logic for maintaining the correct 'current' overlay.
-->

```tsx
overlay.open(
  ({ isOpen, close, unmount }) => {
    return (
      <Modal isOpen={isOpen} onExit={unmount}>
        <div
          style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}
        >
          <p>MODAL CONTENT</p>
          <button onClick={close}>close modal</button>
        </div>
      </Modal>
    );
  },
  { overlayId: 'test' }
);

setTimeout(() => {
  overlay.unmount('test');
  overlay.open(
    ({ isOpen, close, unmount }) => {
      return (
        <Modal isOpen={isOpen} onExit={unmount}>
          <div
            style={{
              display: 'flex',
              flexDirection: 'column',
              alignItems: 'center',
              justifyContent: 'center',
            }}
          >
            <p>MODAL CONTENT</p>
            <button onClick={close}>close modal</button>
          </div>
        </Modal>
      );
    },
    { overlayId: 'test' }
  );
```

## Screenshots (if appropriate):
<!-- (Insert screenshots here if relevant) -->

## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have performed a self-review of my own code.
- [ ] My code is commented, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further Comments
<!-- If there are any further comments or questions, please write them here. -->