### PR TITLE
fix: Change to allow each overlay provider to have a unique ID

### DIFF
--- a/.changeset/quick-humans-bathe.md
+++ b/.changeset/quick-humans-bathe.md
@@ -1,0 +1,5 @@
+---
+"overlay-kit": patch
+---
+
+feat: Change to allow each overlay provider to have a unique event ID

--- a/.changeset/quick-humans-bathe.md
+++ b/.changeset/quick-humans-bathe.md
@@ -3,3 +3,8 @@
 ---
 
 feat: Change to allow each overlay provider to have a unique event ID
+
+Each overlay provider now uses a unique event ID instead of relying on shared global identifiers.
+
+This change improves event handling accuracy and avoids potential collisions when managing multiple overlays from different providers.
+It is backward-compatible for existing overlays that do not explicitly set a provider-specific ID.

--- a/packages/src/context/provider/index.tsx
+++ b/packages/src/context/provider/index.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useReducer, type PropsWithChildren } from 'react';
 import { ContentOverlayController } from './content-overlay-controller';
 import { type OverlayEvent, createOverlay } from '../../event';
+import { randomId } from '../../utils/random-id';
 import { createOverlaySafeContext } from '../context';
 import { overlayReducer } from '../reducer';
 
 export function createOverlayProvider() {
-  const { useOverlayEvent, ...overlay } = createOverlay();
+  const overlayId = randomId();
+  const { useOverlayEvent, ...overlay } = createOverlay(overlayId);
   const { OverlayContextProvider, useCurrentOverlay, useOverlayData } = createOverlaySafeContext();
 
   function OverlayProvider({ children }: PropsWithChildren) {

--- a/packages/src/event.ts
+++ b/packages/src/event.ts
@@ -17,8 +17,8 @@ type OpenOverlayOptions = {
   overlayId?: string;
 };
 
-export function createOverlay() {
-  const [useOverlayEvent, createEvent] = createUseExternalEvents<OverlayEvent>('overlay-kit');
+export function createOverlay(overlayId: string) {
+  const [useOverlayEvent, createEvent] = createUseExternalEvents<OverlayEvent>(`${overlayId}/overlay-kit`);
 
   const open = (controller: OverlayControllerComponent, options?: OpenOverlayOptions) => {
     const overlayId = options?.overlayId ?? randomId();

--- a/packages/src/utils/create-overlay-context.tsx
+++ b/packages/src/utils/create-overlay-context.tsx
@@ -1,6 +1,6 @@
 import { createOverlayProvider } from '../context/provider';
 
-export const { overlay, OverlayProvider, useCurrentOverlay, useOverlayData } = experimental_createOverlayContext();
+export const { overlay, OverlayProvider, useCurrentOverlay, useOverlayData } = createOverlayProvider();
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function experimental_createOverlayContext() {


### PR DESCRIPTION
## Description
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

- Why is this change required?
- What problem does it solve?
- List any dependencies that are required for this change.
-->

This change ensures that each overlay provider is assigned a unique event ID.  

Previously, event IDs were shared or reused across overlay providers, which led to potential collisions and ambiguity during event handling.

**Related Issue:** Fixes #160

## Changes
<!-- 
List the specific changes and modifications made in the codebase. Provide details on what was changed, added, or removed.
- Example: Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Example: Added checks to handle cases where the overlay order is modified.
-->

- Introduced a mechanism to generate and assign unique event IDs per overlay provider.
- Updated the overlay manager logic to utilize the provider-scoped event ID.

## Motivation and Context
<!-- 
Explain the context and background for the change. Why is this change necessary? What problem does it address?
-->

Event IDs are used for tracking and managing overlay-related events. When multiple providers share the same ID space, there is a risk of event handling conflicts or incorrect state transitions.  

This update eliminates such risks by scoping event IDs to the specific provider, enabling more reliable and maintainable event processing in systems with multiple overlays.


## How Has This Been Tested?
<!-- 
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
- Example: Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
- Example: Added unit tests to verify the reducer logic for maintaining the correct 'current' overlay.
-->

- Manually tested multiple overlay providers by triggering event flows concurrently to verify isolation.

```tsx
const { OverlayProvider: CustomOverlayProvider, overlay: customOverlay } = experimental_createOverlayContext();

export function Demo() {
  return (
    <CustomOverlayProvider>
      <button
        onClick={() => {
          overlay.open(() => <div>OVERLAY</div>);
        }}
      >
        overlay.open
      </button>
      <button
        onClick={() => {
          customOverlay.open(() => <div>CUSTOM_OVERLAY</div>);
        }}
      >
        customOverlay.open
      </button>
    </CustomOverlayProvider>
  );
}

...

ReactDOM.createRoot(document.getElementById('root')!).render(
  <React.StrictMode>
    <OverlayProvider>
      <Demo />
    </OverlayProvider>
  </React.StrictMode>
);
```

## Screenshots (if appropriate):
<!-- (Insert screenshots here if relevant) -->

https://github.com/user-attachments/assets/cb43a74a-ffae-4cca-97b3-c1f9d10d31f6

## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [ ] I have performed a self-review of my own code.
- [ ] My code is commented, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further Comments
<!-- If there are any further comments or questions, please write them here. -->