### PR TITLE
fix: wrap overlay mount logic in useEffect hook for proper lifecycle …

### DIFF
--- a/packages/src/context/provider/content-overlay-controller.tsx
+++ b/packages/src/context/provider/content-overlay-controller.tsx
@@ -39,13 +39,15 @@ export function ContentOverlayController({
   /**
    * @description Executes when closing and reopening an overlay without unmounting.
    */
-  if (prevCurrent.current !== current) {
-    prevCurrent.current = current;
+  useEffect(() => {
+    if (prevCurrent.current !== current) {
+      prevCurrent.current = current;
 
-    if (current === overlayId) {
-      onMountedRef.current();
+      if (current === overlayId) {
+        onMountedRef.current();
+      }
     }
-  }
+  }, [current, overlayId]);
 
   useEffect(() => {
     onMountedRef.current();


### PR DESCRIPTION
## Description
Fixed an issue in the ContentOverlayController component where side effects were occurring directly during the rendering phase. Moved these side effects inside useEffect to align with React's rendering model, ensuring that the component behavior follows React's lifecycle properly.

## Changes
- Moved side effects that were occurring directly during rendering into a useEffect hook in the ContentOverlayController component
- Added [current, overlayId] to the dependency array to ensure the effect runs only when these values change

## Motivation and Context
Causing side effects directly within a React component's render function violates React's rules. Render functions should be pure and always return the same output (JSX) for the same input (props and state).

## How Has This Been Tested?
Created test components to compare behavior before and after the changes

- Forced multiple re-renders to observe rendering cycles
- Verified behavior when changing the current value
- Compared differences between before/after implementations by toggling between versions

Tested in React 18 environment with StrictMode enabled to confirm stability

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/e601cc1b-a820-4c95-9701-e05cb3829aca

https://github.com/user-attachments/assets/dd677d31-bd50-46c3-91e9-d91f69ea5feb


## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have performed a self-review of my own code.
- [x] My code is commented, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further Comments
This change follows React's recommended patterns and doesn't affect the external behavior of the component, but significantly improves internal stability and predictability. It ensures more reliable operation, especially in StrictMode or Concurrent Mode environments.