### PR TITLE
fix: prevent unnecessary re-renders of existing overlays with memo

### DIFF
--- a/.changeset/forty-apes-decide.md
+++ b/.changeset/forty-apes-decide.md
@@ -1,0 +1,20 @@
+---
+"overlay-kit": patch
+---
+
+fix: prevent unnecessary re-renders of existing overlays with memo
+
+Prevent unnecessary re-renders of existing overlays when new overlays are opened, improving performance.
+
+### Key Changes
+
+- **Added React.memo**: Applied memo to overlay controller component to prevent re-renders when props haven't changed
+- **Integrated state management**: Streamlined state management by integrating it directly into the component and removing redundant prop passing
+
+### Performance Improvements
+
+- Eliminated unnecessary re-renders of existing overlays when adding new overlays in multi-overlay scenarios
+- Provides more predictable and maintainable state management flow
+- Maintained existing API compatibility while optimizing internal performance
+
+This change maintains backward compatibility and provides performance improvements without requiring any code changes from users. 

--- a/packages/src/context/provider/content-overlay-controller.tsx
+++ b/packages/src/context/provider/content-overlay-controller.tsx
@@ -1,5 +1,5 @@
-import { type FC, useEffect, useRef, ActionDispatch, useCallback, memo } from 'react';
-import { OverlayReducerAction } from '../reducer';
+import { type FC, useEffect, type ActionDispatch, memo } from 'react';
+import { type OverlayReducerAction } from '../reducer';
 
 type OverlayControllerProps = {
   overlayId: string;

--- a/packages/src/context/provider/content-overlay-controller.tsx
+++ b/packages/src/context/provider/content-overlay-controller.tsx
@@ -1,4 +1,5 @@
-import { type FC, useEffect, useRef } from 'react';
+import { type FC, useEffect, useRef, ActionDispatch, useCallback, memo } from 'react';
+import { OverlayReducerAction } from '../reducer';
 
 type OverlayControllerProps = {
   overlayId: string;
@@ -16,40 +17,26 @@ export type OverlayAsyncControllerComponent<T> = FC<OverlayAsyncControllerProps<
 
 type ContentOverlayControllerProps = {
   isOpen: boolean;
-  current: string | null;
   overlayId: string;
-  onMounted: () => void;
-  onCloseModal: () => void;
-  onExitModal: () => void;
+  overlayDispatch: ActionDispatch<[action: OverlayReducerAction]>;
   controller: OverlayControllerComponent;
 };
 
-export function ContentOverlayController({
-  isOpen,
-  current,
-  overlayId,
-  onMounted,
-  onCloseModal,
-  onExitModal,
-  controller: Controller,
-}: ContentOverlayControllerProps) {
-  const prevCurrent = useRef(current);
-  const onMountedRef = useRef(onMounted);
+export const ContentOverlayController = memo(
+  ({ isOpen, overlayId, overlayDispatch, controller: Controller }: ContentOverlayControllerProps) => {
+    useEffect(() => {
+      requestAnimationFrame(() => {
+        overlayDispatch({ type: 'OPEN', overlayId });
+      });
+    }, [overlayDispatch, overlayId]);
 
-  /**
-   * @description Executes when closing and reopening an overlay without unmounting.
-   */
-  if (prevCurrent.current !== current) {
-    prevCurrent.current = current;
-
-    if (current === overlayId) {
-      onMountedRef.current();
-    }
+    return (
+      <Controller
+        overlayId={overlayId}
+        isOpen={isOpen}
+        close={() => overlayDispatch({ type: 'CLOSE', overlayId })}
+        unmount={() => overlayDispatch({ type: 'REMOVE', overlayId })}
+      />
+    );
   }
-
-  useEffect(() => {
-    onMountedRef.current();
-  }, []);
-
-  return <Controller overlayId={overlayId} isOpen={isOpen} close={onCloseModal} unmount={onExitModal} />;
-}
+);

--- a/packages/src/context/provider/index.tsx
+++ b/packages/src/context/provider/index.tsx
@@ -64,15 +64,8 @@ export function createOverlayProvider() {
             <ContentOverlayController
               key={componentKey}
               isOpen={isOpen}
-              current={overlayState.current}
               overlayId={currentOverlayId}
-              onMounted={() => {
-                requestAnimationFrame(() => {
-                  overlayDispatch({ type: 'OPEN', overlayId: currentOverlayId });
-                });
-              }}
-              onCloseModal={() => overlay.close(currentOverlayId)}
-              onExitModal={() => overlay.unmount(currentOverlayId)}
+              overlayDispatch={overlayDispatch}
               controller={currentController}
             />
           );

--- a/packages/src/context/reducer.ts
+++ b/packages/src/context/reducer.ts
@@ -20,7 +20,7 @@ export type OverlayData = {
   overlayData: Record<OverlayId, OverlayItem>;
 };
 
-type OverlayReducerAction =
+export type OverlayReducerAction =
   | { type: 'ADD'; overlay: OverlayItem }
   | { type: 'OPEN'; overlayId: string }
   | { type: 'CLOSE'; overlayId: string }


### PR DESCRIPTION
## Description
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

- Why is this change required?
- What problem does it solve?
- List any dependencies that are required for this change.
-->

This PR optimizes overlay controller performance by preventing unnecessary re-renders of existing overlays when new overlays are opened.

The solution integrates React.memo to prevent re-rendering and streamlines state management by integrating it directly into the component.

- **Why is this change required?** Currently, when a new overlay is opened, all existing overlays re-render unnecessarily, causing performance issues.
- **What problem does it solve?** Eliminates unnecessary re-renders of existing overlays, improving application performance and user experience.
- **Dependencies:** No additional dependencies required.

**Related Issue:** Fixes # (issue_number)

## Changes
<!-- 
List the specific changes and modifications made in the codebase. Provide details on what was changed, added, or removed.
- Example: Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Example: Added checks to handle cases where the overlay order is modified.
-->

- Added React.memo to overlay controller component to prevent unnecessary re-renders
- Integrated state management directly into the overlay controller component
- Removed redundant props that were causing unnecessary re-renders
- Updated overlay dispatch logic for opening, closing, and unmounting overlays
- Modified reducer logic to ensure optimal state management flow

## Motivation and Context
<!-- 
Explain the context and background for the change. Why is this change necessary? What problem does it address?
-->

When multiple overlays are present in the application, opening a new overlay would trigger re-renders of all existing overlays, even though their state and props hadn't changed.

This created performance bottlenecks, especially in applications with multiple overlays.
By adding memo and streamlining the state management, we ensure that overlays only re-render when their specific state changes.

## How Has This Been Tested?
<!-- 
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
- Example: Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
- Example: Added unit tests to verify the reducer logic for maintaining the correct 'current' overlay.
-->


- Manually tested opening multiple overlays in sequence to verify existing overlays don't re-render

## Screenshots (if appropriate):
<!-- (Insert screenshots here if relevant) -->

## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have performed a self-review of my own code.
- [ ] My code is commented, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Further Comments
<!-- If there are any further comments or questions, please write them here. -->