### PR TITLE
fix: enable reopening overlay after `close()` with `overlay.open`

### DIFF
--- a/.changeset/tiny-pots-fail.md
+++ b/.changeset/tiny-pots-fail.md
@@ -1,0 +1,18 @@
+---
+"overlay-kit": patch
+---
+
+Fixed a bug where overlays could not be reopened after closing with the same ID.
+
+### Fixed Issues
+- Resolved issue where overlays would not display when reopened with the same `overlayId` after being closed
+- Improved mounting state tracking with added `isMounted` property in overlay state management
+- Added state change detection logic to ensure proper reopen handling
+
+### Changes
+- Added `isMounted` property to `OverlayItem` type for better mounting state tracking
+- Enhanced `ADD` action in reducer to handle reopening of existing closed overlays
+- Implemented automatic reopen mechanism through state comparison in `OverlayProvider`
+- Added test cases for overlay reopen scenarios
+
+This fix ensures overlays work as expected when closing and reopening them. 

--- a/packages/src/context/provider/content-overlay-controller.tsx
+++ b/packages/src/context/provider/content-overlay-controller.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, type ActionDispatch, memo } from 'react';
+import { type FC, type ActionDispatch, memo } from 'react';
 import { type OverlayReducerAction } from '../reducer';
 
 type OverlayControllerProps = {
@@ -24,16 +24,10 @@ type ContentOverlayControllerProps = {
 
 export const ContentOverlayController = memo(
   ({ isOpen, overlayId, overlayDispatch, controller: Controller }: ContentOverlayControllerProps) => {
-    useEffect(() => {
-      requestAnimationFrame(() => {
-        overlayDispatch({ type: 'OPEN', overlayId });
-      });
-    }, [overlayDispatch, overlayId]);
-
     return (
       <Controller
-        overlayId={overlayId}
         isOpen={isOpen}
+        overlayId={overlayId}
         close={() => overlayDispatch({ type: 'CLOSE', overlayId })}
         unmount={() => overlayDispatch({ type: 'REMOVE', overlayId })}
       />

--- a/packages/src/context/provider/content-overlay-controller.tsx
+++ b/packages/src/context/provider/content-overlay-controller.tsx
@@ -1,4 +1,4 @@
-import { type FC, type ActionDispatch, memo } from 'react';
+import { type FC, type ActionDispatch, memo, useEffect } from 'react';
 import { type OverlayReducerAction } from '../reducer';
 
 type OverlayControllerProps = {
@@ -24,6 +24,12 @@ type ContentOverlayControllerProps = {
 
 export const ContentOverlayController = memo(
   ({ isOpen, overlayId, overlayDispatch, controller: Controller }: ContentOverlayControllerProps) => {
+    useEffect(() => {
+      requestAnimationFrame(() => {
+        overlayDispatch({ type: 'OPEN', overlayId });
+      });
+    }, [overlayDispatch, overlayId]);
+
     return (
       <Controller
         isOpen={isOpen}

--- a/packages/src/context/provider/index.tsx
+++ b/packages/src/context/provider/index.tsx
@@ -44,12 +44,39 @@ export function createOverlayProvider() {
 
     useOverlayEvent({ open, close, unmount, closeAll, unmountAll });
 
+    /**
+     * @TODO
+     * Due to React batching, only the current of the last modal can be recognized,
+     * so when n modals closed by close are opened at once with overlay.open,
+     * some modals may not open.
+     *
+     * To solve this, prevOverlayState.current.overlayData's isOpen should be false,
+     * and overlayState.overlayData's isOpen should be true.
+     * Reducer modification is needed to handle this part, and since this issue
+     * has existed from before, we'll skip it for now.
+     */
     if (prevOverlayState.current !== overlayState) {
-      prevOverlayState.current = overlayState;
+      // mounted overlay open
+      overlayState.overlayOrderList.forEach((overlayId) => {
+        if (prevOverlayState.current.overlayData[overlayId] == null) {
+          requestAnimationFrame(() => {
+            overlayDispatch({ type: 'OPEN', overlayId });
+          });
+        }
+      });
 
-      if (overlayState.current != null && overlayState.overlayData[overlayState.current].isOpen === false) {
-        overlayDispatch({ type: 'OPEN', overlayId: overlayState.current });
+      // reopened overlay open
+      if (overlayState.current != null && prevOverlayState.current.overlayData[overlayState.current] != null) {
+        const isPrevOverlayClosed = prevOverlayState.current.overlayData[overlayState.current].isOpen === false;
+
+        if (isPrevOverlayClosed) {
+          requestAnimationFrame(() => {
+            overlayDispatch({ type: 'OPEN', overlayId: overlayState.current! });
+          });
+        }
       }
+
+      prevOverlayState.current = overlayState;
     }
 
     useEffect(() => {

--- a/packages/src/context/provider/index.tsx
+++ b/packages/src/context/provider/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, type PropsWithChildren } from 'react';
+import { useCallback, useEffect, useReducer, useRef, type PropsWithChildren } from 'react';
 import { ContentOverlayController } from './content-overlay-controller';
 import { type OverlayEvent, createOverlay } from '../../event';
 import { randomId } from '../../utils/random-id';
@@ -16,6 +16,7 @@ export function createOverlayProvider() {
       overlayOrderList: [],
       overlayData: {},
     });
+    const prevOverlayState = useRef(overlayState);
 
     const open: OverlayEvent['open'] = useCallback(({ controller, overlayId, componentKey }) => {
       overlayDispatch({
@@ -43,6 +44,14 @@ export function createOverlayProvider() {
 
     useOverlayEvent({ open, close, unmount, closeAll, unmountAll });
 
+    if (prevOverlayState.current !== overlayState) {
+      prevOverlayState.current = overlayState;
+
+      if (overlayState.current != null && overlayState.overlayData[overlayState.current].isOpen === false) {
+        overlayDispatch({ type: 'OPEN', overlayId: overlayState.current });
+      }
+    }
+
     useEffect(() => {
       return () => {
         overlayDispatch({ type: 'REMOVE_ALL' });
@@ -53,20 +62,15 @@ export function createOverlayProvider() {
       <OverlayContextProvider value={overlayState}>
         {children}
         {overlayState.overlayOrderList.map((item) => {
-          const {
-            id: currentOverlayId,
-            componentKey,
-            isOpen,
-            controller: currentController,
-          } = overlayState.overlayData[item];
+          const { id: currentOverlayId, componentKey, isOpen, controller: Controller } = overlayState.overlayData[item];
 
           return (
             <ContentOverlayController
               key={componentKey}
               isOpen={isOpen}
+              controller={Controller}
               overlayId={currentOverlayId}
               overlayDispatch={overlayDispatch}
-              controller={currentController}
             />
           );
         })}

--- a/packages/src/context/provider/index.tsx
+++ b/packages/src/context/provider/index.tsx
@@ -25,6 +25,7 @@ export function createOverlayProvider() {
           id: overlayId,
           componentKey,
           isOpen: false,
+          isMounted: false,
           controller: controller,
         },
       });
@@ -44,37 +45,22 @@ export function createOverlayProvider() {
 
     useOverlayEvent({ open, close, unmount, closeAll, unmountAll });
 
-    /**
-     * @TODO
-     * Due to React batching, only the current of the last modal can be recognized,
-     * so when n modals closed by close are opened at once with overlay.open,
-     * some modals may not open.
-     *
-     * To solve this, prevOverlayState.current.overlayData's isOpen should be false,
-     * and overlayState.overlayData's isOpen should be true.
-     * Reducer modification is needed to handle this part, and since this issue
-     * has existed from before, we'll skip it for now.
-     */
     if (prevOverlayState.current !== overlayState) {
-      // mounted overlay open
       overlayState.overlayOrderList.forEach((overlayId) => {
-        if (prevOverlayState.current.overlayData[overlayId] == null) {
-          requestAnimationFrame(() => {
-            overlayDispatch({ type: 'OPEN', overlayId });
-          });
+        const prevOverlayData = prevOverlayState.current.overlayData;
+        const currOverlayData = overlayState.overlayData;
+
+        if (prevOverlayData[overlayId] != null && prevOverlayData[overlayId].isMounted === true) {
+          const isPrevOverlayClosed = prevOverlayData[overlayId].isOpen === false;
+          const isCurrOverlayOpened = currOverlayData[overlayId].isOpen === true;
+
+          if (isPrevOverlayClosed && isCurrOverlayOpened) {
+            requestAnimationFrame(() => {
+              overlayDispatch({ type: 'OPEN', overlayId });
+            });
+          }
         }
       });
-
-      // reopened overlay open
-      if (overlayState.current != null && prevOverlayState.current.overlayData[overlayState.current] != null) {
-        const isPrevOverlayClosed = prevOverlayState.current.overlayData[overlayState.current].isOpen === false;
-
-        if (isPrevOverlayClosed) {
-          requestAnimationFrame(() => {
-            overlayDispatch({ type: 'OPEN', overlayId: overlayState.current! });
-          });
-        }
-      }
 
       prevOverlayState.current = overlayState;
     }

--- a/packages/src/context/reducer.ts
+++ b/packages/src/context/reducer.ts
@@ -74,6 +74,7 @@ export function overlayReducer(state: OverlayData, action: OverlayReducerAction)
 
         return {
           ...state,
+          current: action.overlay.id,
           overlayData: {
             ...state.overlayData,
             [action.overlay.id]: { ...overlay, isOpen: true },

--- a/packages/src/context/reducer.ts
+++ b/packages/src/context/reducer.ts
@@ -12,6 +12,7 @@ type OverlayItem = {
    */
   componentKey: string;
   isOpen: boolean;
+  isMounted: boolean;
   controller: OverlayControllerComponent;
 };
 export type OverlayData = {
@@ -63,6 +64,23 @@ export const determineCurrentOverlayId = (
 export function overlayReducer(state: OverlayData, action: OverlayReducerAction): OverlayData {
   switch (action.type) {
     case 'ADD': {
+      if (state.overlayData[action.overlay.id] != null && state.overlayData[action.overlay.id].isOpen === false) {
+        const overlay = state.overlayData[action.overlay.id];
+
+        // ignore if the overlay don't exist or already open
+        if (overlay == null || overlay.isOpen) {
+          return state;
+        }
+
+        return {
+          ...state,
+          overlayData: {
+            ...state.overlayData,
+            [action.overlay.id]: { ...overlay, isOpen: true },
+          },
+        };
+      }
+
       const isExisted = state.overlayOrderList.includes(action.overlay.id);
 
       if (isExisted && state.overlayData[action.overlay.id].isOpen === true) {
@@ -97,10 +115,7 @@ export function overlayReducer(state: OverlayData, action: OverlayReducerAction)
         ...state,
         overlayData: {
           ...state.overlayData,
-          [action.overlayId]: {
-            ...overlay,
-            isOpen: true,
-          },
+          [action.overlayId]: { ...overlay, isOpen: true, isMounted: true },
         },
       };
     }

--- a/packages/src/event.test.tsx
+++ b/packages/src/event.test.tsx
@@ -286,6 +286,13 @@ describe('overlay object', () => {
       expect(screen.queryByTestId(/^overlay-/)).not.toBeInTheDocument();
       expect(screen.queryByText('has Open overlay')).not.toBeInTheDocument();
     });
+
+    overlay.open(({ isOpen }) => isOpen && <div data-testid="overlay-1">{contents.first}</div>);
+    overlay.open(({ isOpen }) => isOpen && <div data-testid="overlay-2">{contents.second}</div>);
+    await waitFor(() => {
+      expect(screen.getByTestId('overlay-1')).toBeInTheDocument();
+      expect(screen.getByTestId('overlay-2')).toBeInTheDocument();
+    });
   });
 
   it('should not be able to get current overlay when all overlays are closed', async () => {

--- a/packages/src/event.test.tsx
+++ b/packages/src/event.test.tsx
@@ -414,4 +414,39 @@ describe('overlay object', () => {
       expect(screen.getByTestId('overlay-1')).toBeInTheDocument();
     });
   });
+
+  it('should be able to open an overlay after closing it', async () => {
+    const overlayId = 'overlay-content-1';
+
+    function Component() {
+      const current = useCurrentOverlay();
+
+      useEffect(() => {
+        overlay.open(({ isOpen }) => isOpen && <div data-testid="overlay-1">{overlayId}</div>, {
+          overlayId: overlayId,
+        });
+      }, []);
+
+      return <div data-testid="current-overlay">{current}</div>;
+    }
+
+    render(<Component />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('overlay-1')).toBeVisible();
+      expect(screen.getByTestId('current-overlay')).toHaveTextContent(overlayId);
+    });
+
+    overlay.close(overlayId);
+    await waitFor(() => {
+      expect(screen.queryByTestId('overlay-1')).not.toBeInTheDocument();
+      expect(screen.getByTestId('current-overlay')).toHaveTextContent('');
+    });
+
+    overlay.open(({ isOpen }) => isOpen && <div data-testid="overlay-1">{overlayId}</div>, { overlayId });
+    await waitFor(() => {
+      expect(screen.getByTestId('overlay-1')).toBeVisible();
+      expect(screen.getByTestId('current-overlay')).toHaveTextContent(overlayId);
+    });
+  });
 });


### PR DESCRIPTION
## Description
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

- Why is this change required?
- What problem does it solve?
- List any dependencies that are required for this change.
-->

This PR fixes a bug where overlays could not be reopened after being closed when using the same overlay ID. The issue occurred because the overlay state management didn't properly handle the case where an overlay was closed and then reopened with the same identifier.

**Related Issue:** Fixes #186

## Changes
<!-- 
List the specific changes and modifications made in the codebase. Provide details on what was changed, added, or removed.
- Example: Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Example: Added checks to handle cases where the overlay order is modified.
-->

- Added `isMounted` property to `OverlayItem` type to track overlay mounting state
- Modified the `ADD` action in reducer to handle reopening of existing closed overlays
- Added state comparison logic in `OverlayProvider` to detect overlay state changes and trigger proper reopening
- Updated `OPEN` action to set `isMounted: true` when opening overlays
- Added `useRef` to track previous overlay state for comparison
- Restructured overlay controller props order and import statements for consistency
- Added comprehensive test case for overlay close and reopen functionality

## Motivation and Context
<!-- 
Explain the context and background for the change. Why is this change necessary? What problem does it address?
-->

Previously, when an overlay was closed and then reopened with the same overlay ID, the overlay would not properly display again. This was because the overlay state management system didn't distinguish between completely new overlays and overlays that were being reopened after being closed. The system would skip the reopening process for existing overlay IDs, even if they were in a closed state.

This fix ensures that:
1. Overlays can be properly reopened after being closed
2. The mounting state is correctly tracked and managed
3. State transitions are properly handled through animation frames to ensure smooth UI updates

## How Has This Been Tested?
<!-- 
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
- Example: Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
- Example: Added unit tests to verify the reducer logic for maintaining the correct 'current' overlay.
-->

- Added a comprehensive unit test that verifies overlay close and reopen functionality
- The test creates an overlay, opens it, verifies it's visible, closes it, verifies it's hidden, then reopens it with the same ID and verifies it's visible again
- Tested with multiple overlay scenarios to ensure no regression in existing functionality
- Verified that overlay state management works correctly across different React versions (16, 17, 18, 19)
- Manual testing confirmed smooth transitions and proper overlay behavior

## Screenshots (if appropriate):
<!-- (Insert screenshots here if relevant) -->

N/A - This is a functional bug fix without visual changes

## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have performed a self-review of my own code.
- [x] My code is commented, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Further Comments
<!-- If there are any further comments or questions, please write them here. -->

This fix addresses a critical issue that could affect user experience when working with modal/overlay patterns. The solution maintains backward compatibility while ensuring proper state management for overlay reopening scenarios.