### PR TITLE
docs: correct `overlay.close()` to `overlay.closeAll()` in overlay.closeAll documentation

### DIFF
--- a/docs/src/pages/en/api/utils/overlay-close-all.mdx
+++ b/docs/src/pages/en/api/utils/overlay-close-all.mdx
@@ -10,7 +10,7 @@ overlay.closeAll();
 
 ## Reference
 
-`overlay.close()`
+`overlay.closeAll()`
 
 Call `overlay.closeAll` when you need to close all open overlays.
 

--- a/docs/src/pages/ko/api/utils/overlay-close-all.mdx
+++ b/docs/src/pages/ko/api/utils/overlay-close-all.mdx
@@ -10,7 +10,7 @@ overlay.closeAll();
 
 ## 레퍼런스
 
-`overlay.close()`
+`overlay.closeAll()`
 
 열려있는 모든 오버레이를 닫을 때 `overlay.closeAll`을 호출하세요.
 


### PR DESCRIPTION
## Description

This PR fixes the documentation of the overlay.closeAll function by correcting a mistaken reference to `overlay.close()` and replacing it with the correct `overlay.closeAll()`. This change is required to prevent user confusion and ensure that the documentation accurately reflects the intended function to be called when closing all overlays.

## Changes

- Corrected the reference from `overlay.close()` to `overlay.closeAll()` in the References section and other relevant parts of the overlay.closeAll documentation.
- Updated code examples to consistently use `overlay.closeAll()` where all overlays are being closed.

## Motivation and Context

The incorrect reference to `overlay.close()` in the overlay.closeAll documentation could mislead users into calling the wrong method when intending to close all active overlays. This update ensures clarity and helps users follow the correct usage pattern, improving overall developer experience and reducing potential misuse.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
- [X] I have performed a self-review of my own code.
- [] My code is commented, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

