### PR TITLE
docs: eliminate redundant extra questions notice from FAQ introduction

### DIFF
--- a/docs/src/pages/en/docs/guides/faq.mdx
+++ b/docs/src/pages/en/docs/guides/faq.mdx
@@ -2,8 +2,6 @@
 
 Here are common questions and answers about using `overlay-kit`.
 
-If you have additional questions or find topics not covered in the documentation, please leave your feedback in [GitHub Issues](https://github.com/toss/overlay-kit/issues).
-
 ## Q. When is overlay-kit most useful?
 
 **A:**

--- a/docs/src/pages/ko/docs/guides/faq.mdx
+++ b/docs/src/pages/ko/docs/guides/faq.mdx
@@ -2,8 +2,6 @@
 
 `overlay-kit`을 사용하며 자주 나오는 질문과 답변을 모았습니다.
 
-추가로 궁금한 점이 있거나 문서에서 다루지 않은 내용이 있다면 [GitHub Issues](https://github.com/toss/overlay-kit/issues)에 의견을 남겨주세요.
-
 ## Q. overlay-kit은 어떤 상황에서 가장 유용한가요?
 
 **A:**


### PR DESCRIPTION
## Description

This PR removes the duplicated extra questions prompt from the top of the FAQ page. Since the FAQ already includes a dedicated section with the same message at the end, this removal improves readability and avoids redundancy.

## Changes

- Deleted the extra questions prompt sentence from the FAQ introduction.

## Motivation and Context

Repeating the same prompt at both the beginning and end of the FAQ can cause clutter and give a less polished impression. Removing the redundant sentence helps the document feel cleaner and more user-friendly.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist

- [X] I have performed a self-review of my own code.
- [ ] My code is commented, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
