### PR TITLE
refactor: Improve test coverage by removing unreachable defensive code in determineCurrentOverlayId

### DIFF
--- a/.changeset/tiny-beers-joke.md
+++ b/.changeset/tiny-beers-joke.md
@@ -1,0 +1,5 @@
+---
+"overlay-kit": patch
+---
+
+refactor: Improve test coverage by removing unreachable defensive code in determineCurrentOverlayId

--- a/packages/src/context/reducer.ts
+++ b/packages/src/context/reducer.ts
@@ -58,7 +58,7 @@ export const determineCurrentOverlayId = (
 
   return targetIndexInOpenedList === openedOverlayOrderList.length - 1
     ? openedOverlayOrderList[targetIndexInOpenedList - 1] ?? null
-    : openedOverlayOrderList.at(-1) ?? null;
+    : openedOverlayOrderList[openedOverlayOrderList.length - 1];
 };
 
 export function overlayReducer(state: OverlayData, action: OverlayReducerAction): OverlayData {


### PR DESCRIPTION
## Description  
  
This PR improves test coverage by removing unreachable defensive code in the `determineCurrentOverlayId` function. When closing an intermediate overlay, the function uses `.at(-1)` which has a return type of `T | undefined`, requiring a `?? null` defensive operator. However, this defensive code is logically unreachable because when closing an intermediate overlay, `openedOverlayOrderList` always contains at least 2 elements, making `.at(-1)` guaranteed to return a value.  
  
- **Why is this change required?** The `?? null` defensive code in the intermediate overlay branch is unreachable, causing test coverage to drop unnecessarily.  
- **What problem does it solve?** Improves test coverage by replacing `.at(-1) ?? null` with direct array indexing `[openedOverlayOrderList.length - 1]`, which TypeScript correctly types as `OverlayId` without requiring defensive code.  
  
## Changes  
  
- Replaced `openedOverlayOrderList.at(-1) ?? null` with `openedOverlayOrderList[openedOverlayOrderList.length - 1]`  
- This change eliminates unreachable defensive code while maintaining identical runtime behavior  
  
## Motivation and Context  
  
The `determineCurrentOverlayId` function determines which overlay should receive focus when an overlay is closed or removed. It handles two cases:  
  
1. **Closing the last overlay**: Returns the previous overlay (or null if it's the only one)  
2. **Closing an intermediate overlay**: Returns the last overlay in the stack  
  
In the second case, the function previously used `.at(-1) ?? null`. However, when closing an intermediate overlay, `openedOverlayOrderList` must contain at least 2 elements (the target overlay and at least one overlay after it), making the `?? null` defensive code logically unreachable. This unreachable code path caused test coverage to drop.  
  
By using direct array indexing `[openedOverlayOrderList.length - 1]`, we:  
- Eliminate the unreachable code path  
- Improve test coverage  
- Make the code's intent clearer (we know the element exists)  
- Maintain type safety without unnecessary defensive programming  
  
## How Has This Been Tested?  
  
- All existing unit tests in `packages/src/context/reducer.test.ts` pass without modification  
- Verified test coverage improved by eliminating the unreachable branch  
- No changes to runtime behavior - the function produces identical results  
  
## Screenshots (if appropriate):  

| Before | After |
|:------:|:-----:|
|  <img width="781" height="335" alt="스크린샷 2025-10-10 오후 5 06 15" src="https://github.com/user-attachments/assets/7a3e82c7-14a8-4739-8a91-62cae3cf39ec" />|   <img width="790" height="330" alt="스크린샷 2025-10-10 오후 5 06 59" src="https://github.com/user-attachments/assets/750971b6-7dd5-4118-abb6-ae1ba01ad321" />|

Test coverage branches: `85.71` ➔ `100`
  
## Types of changes  
  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Documentation update  
  
## Checklist  
  
- [x] I have performed a self-review of my own code.  
- [ ] My code is commented, particularly in hard-to-understand areas.  
- [ ] I have made corresponding changes to the documentation.  
- [x] My changes generate no new warnings.  
- [ ] I have added tests that prove my fix is effective or that my feature works.  
- [ ] New and existing unit tests pass locally with my changes.  
- [ ] Any dependent changes have been merged and published in downstream modules.  
