### PR TITLE
Fix openAsync example tristate pattern

### DIFF
--- a/docs/src/pages/en/docs/more/basic.mdx
+++ b/docs/src/pages/en/docs/more/basic.mdx
@@ -71,7 +71,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 
 function App() {
-  const [result, setResult] = useState<boolean>();
+  const [result, setResult] = useState<boolean | null>(null);
 
   return (
     <div>
@@ -94,7 +94,7 @@ function App() {
       >
         Open Confirm Dialog
       </Button>
-      <p>result: {result ? 'Y' : 'N'}</p>
+      <p>{result === null ? 'Not selected' : result ? 'result: Y' : 'result: N'}</p>
     </div>
   );
 }

--- a/docs/src/pages/ko/docs/more/basic.mdx
+++ b/docs/src/pages/ko/docs/more/basic.mdx
@@ -71,7 +71,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 
 function App() {
-  const [result, setResult] = useState<boolean>();
+  const [result, setResult] = useState<boolean | null>(null);
 
   return (
     <div>
@@ -94,7 +94,7 @@ function App() {
       >
         Confirm Dialog 열기
       </Button>
-      <p>result: {result ? 'Y' : 'N'}</p>
+      <p>{result === null ? 'Not selected' : result ? 'result: Y' : 'result: N'}</p>
     </div>
   );
 }


### PR DESCRIPTION
This PR fixes the openAsync example to properly demonstrate the tristate pattern (true/false/undefined) for better understanding of the API usage.