### PR TITLE
fix(openAsync): resolve promise when closed externally

### DIFF
--- a/examples/react-16/framer-motion/src/demo.tsx
+++ b/examples/react-16/framer-motion/src/demo.tsx
@@ -107,7 +107,7 @@ function DemoOpenAsyncBasic() {
 
 function DemoOpenAsyncWithDefaultValue() {
   const [result, setResult] = useState<string>('(no result yet)');
-  const [overlayId] = useState('defaultvalue-demo-overlay');
+  const overlayId = 'defaultvalue-demo-overlay';
 
   return (
     <div>
@@ -120,53 +120,66 @@ function DemoOpenAsyncWithDefaultValue() {
       <p>
         Result: <strong>{result}</strong>
       </p>
-      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
-        <button
-          onClick={async () => {
-            setResult('(waiting...)');
-            const value = await overlay.openAsync<boolean>(
-              ({ isOpen, close, unmount }) => {
-                return (
-                  <Modal isOpen={isOpen} onExit={unmount}>
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        gap: 10,
-                      }}
-                    >
-                      <p>Do you confirm?</p>
-                      <p style={{ fontSize: 12, color: '#666' }}>(Try clicking "Close Externally" button below)</p>
-                      <div style={{ display: 'flex', gap: 10 }}>
-                        <button onClick={() => close(true)}>Confirm (true)</button>
-                        <button onClick={() => close(false)}>Cancel (false)</button>
-                      </div>
+      <button
+        onClick={async () => {
+          setResult('(waiting...)');
+          const value = await overlay.openAsync<boolean>(
+            ({ isOpen, close, unmount }) => {
+              return (
+                <Modal isOpen={isOpen} onExit={unmount}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 10,
+                    }}
+                  >
+                    <p>Do you confirm?</p>
+                    <div style={{ display: 'flex', gap: 10 }}>
+                      <button onClick={() => close(true)}>Confirm (true)</button>
+                      <button onClick={() => close(false)}>Cancel (false)</button>
                     </div>
-                  </Modal>
-                );
-              },
-              { overlayId, defaultValue: false }
-            );
-            setResult(String(value));
-          }}
-        >
-          open dialog
-        </button>
-        <button
-          onClick={() => overlay.close(overlayId)}
-          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
-        >
-          Close Externally (→ false)
-        </button>
-        <button
-          onClick={() => overlay.closeAll()}
-          style={{ backgroundColor: '#ffa94d', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
-        >
-          Close All (→ false)
-        </button>
-      </div>
+                    <hr style={{ width: '100%', margin: '10px 0' }} />
+                    <p style={{ fontSize: 12, color: '#666' }}>External close (uses overlay.close):</p>
+                    <div style={{ display: 'flex', gap: 10 }}>
+                      <button
+                        onClick={() => overlay.close(overlayId)}
+                        style={{
+                          backgroundColor: '#ff6b6b',
+                          color: 'white',
+                          border: 'none',
+                          padding: '8px 16px',
+                          borderRadius: 4,
+                        }}
+                      >
+                        overlay.close() → false
+                      </button>
+                      <button
+                        onClick={() => overlay.closeAll()}
+                        style={{
+                          backgroundColor: '#ffa94d',
+                          color: 'white',
+                          border: 'none',
+                          padding: '8px 16px',
+                          borderRadius: 4,
+                        }}
+                      >
+                        overlay.closeAll() → false
+                      </button>
+                    </div>
+                  </div>
+                </Modal>
+              );
+            },
+            { overlayId, defaultValue: false }
+          );
+          setResult(String(value));
+        }}
+      >
+        open dialog
+      </button>
     </div>
   );
 }
@@ -174,7 +187,7 @@ function DemoOpenAsyncWithDefaultValue() {
 function DemoExternalClose() {
   const [result, setResult] = useState<string>('(no result yet)');
   const [status, setStatus] = useState<'idle' | 'waiting'>('idle');
-  const [overlayId] = useState('external-close-demo-overlay');
+  const overlayId = 'external-close-demo-overlay';
 
   return (
     <div>
@@ -188,45 +201,51 @@ function DemoExternalClose() {
       <p>
         Status: <strong style={{ color: status === 'waiting' ? 'orange' : 'green' }}>{status}</strong>
       </p>
-      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
-        <button
-          onClick={async () => {
-            setResult('(no result yet)');
-            setStatus('waiting');
-            const value = await overlay.openAsync<boolean>(
-              ({ isOpen, close, unmount }) => {
-                return (
-                  <Modal isOpen={isOpen} onExit={unmount}>
-                    <div
+      <button
+        onClick={async () => {
+          setResult('(no result yet)');
+          setStatus('waiting');
+          const value = await overlay.openAsync<boolean>(
+            ({ isOpen, close, unmount }) => {
+              return (
+                <Modal isOpen={isOpen} onExit={unmount}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 10,
+                    }}
+                  >
+                    <p>Without defaultValue, external close keeps Promise pending</p>
+                    <button onClick={() => close(true)}>close(true) - resolves</button>
+                    <hr style={{ width: '100%', margin: '10px 0' }} />
+                    <p style={{ fontSize: 12, color: '#666' }}>External close (Promise stays pending!):</p>
+                    <button
+                      onClick={() => overlay.close(overlayId)}
                       style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        gap: 10,
+                        backgroundColor: '#ff6b6b',
+                        color: 'white',
+                        border: 'none',
+                        padding: '8px 16px',
+                        borderRadius: 4,
                       }}
                     >
-                      <p>Click "Close Externally" - Promise will stay pending!</p>
-                      <button onClick={() => close(true)}>Close Internally (resolves)</button>
-                    </div>
-                  </Modal>
-                );
-              },
-              { overlayId }
-            );
-            setResult(String(value));
-            setStatus('idle');
-          }}
-        >
-          open dialog
-        </button>
-        <button
-          onClick={() => overlay.close(overlayId)}
-          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
-        >
-          Close Externally (Promise stays pending)
-        </button>
-      </div>
+                      overlay.close() - NO resolve
+                    </button>
+                  </div>
+                </Modal>
+              );
+            },
+            { overlayId }
+          );
+          setResult(String(value));
+          setStatus('idle');
+        }}
+      >
+        open dialog
+      </button>
     </div>
   );
 }

--- a/examples/react-16/framer-motion/src/demo.tsx
+++ b/examples/react-16/framer-motion/src/demo.tsx
@@ -4,9 +4,18 @@ import { Modal } from './components/modal.tsx';
 
 export function Demo() {
   return (
-    <div>
+    <div style={{ padding: 20, fontFamily: 'system-ui, sans-serif' }}>
+      <h1>overlay-kit Examples</h1>
+      <hr style={{ margin: '20px 0' }} />
       <DemoWithState />
+      <hr style={{ margin: '20px 0' }} />
       <DemoWithEsOverlay />
+      <hr style={{ margin: '20px 0' }} />
+      <DemoOpenAsyncBasic />
+      <hr style={{ margin: '20px 0' }} />
+      <DemoOpenAsyncWithOnDismiss />
+      <hr style={{ margin: '20px 0' }} />
+      <DemoExternalClose />
     </div>
   );
 }
@@ -16,7 +25,7 @@ function DemoWithState() {
 
   return (
     <div>
-      <p>Demo with useState</p>
+      <h2>1. Demo with useState</h2>
       <button onClick={() => setIsOpen(true)}>open modal</button>
       <Modal isOpen={isOpen}>
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
@@ -31,7 +40,7 @@ function DemoWithState() {
 function DemoWithEsOverlay() {
   return (
     <div>
-      <p>Demo with overlay-kit</p>
+      <h2>2. Demo with overlay.open</h2>
       <button
         onClick={() => {
           overlay.open(({ isOpen, close, unmount }) => {
@@ -50,6 +59,172 @@ function DemoWithEsOverlay() {
       >
         open modal
       </button>
+    </div>
+  );
+}
+
+function DemoOpenAsyncBasic() {
+  const [result, setResult] = useState<string>('(no result yet)');
+
+  return (
+    <div>
+      <h2>3. Demo with overlay.openAsync (basic)</h2>
+      <p>
+        Result: <strong>{result}</strong>
+      </p>
+      <button
+        onClick={async () => {
+          setResult('(waiting...)');
+          const value = await overlay.openAsync<boolean>(({ isOpen, close, unmount }) => {
+            return (
+              <Modal isOpen={isOpen} onExit={unmount}>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: 10,
+                  }}
+                >
+                  <p>Do you confirm?</p>
+                  <div style={{ display: 'flex', gap: 10 }}>
+                    <button onClick={() => close(true)}>Confirm (true)</button>
+                    <button onClick={() => close(false)}>Cancel (false)</button>
+                  </div>
+                </div>
+              </Modal>
+            );
+          });
+          setResult(String(value));
+        }}
+      >
+        open confirm dialog
+      </button>
+    </div>
+  );
+}
+
+function DemoOpenAsyncWithOnDismiss() {
+  const [result, setResult] = useState<string>('(no result yet)');
+  const [overlayId] = useState('ondismiss-demo-overlay');
+
+  return (
+    <div>
+      <h2>4. Demo with overlay.openAsync + defaultValue option</h2>
+      <p style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
+        With <code>defaultValue</code>, the Promise resolves even when closed externally.
+      </p>
+      <p>
+        Result: <strong>{result}</strong>
+      </p>
+      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
+        <button
+          onClick={async () => {
+            setResult('(waiting...)');
+            const value = await overlay.openAsync<boolean | 'dismissed'>(
+              ({ isOpen, close, unmount }) => {
+                return (
+                  <Modal isOpen={isOpen} onExit={unmount}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 10,
+                      }}
+                    >
+                      <p>Do you confirm?</p>
+                      <p style={{ fontSize: 12, color: '#666' }}>(Try clicking "Close Externally" button below)</p>
+                      <div style={{ display: 'flex', gap: 10 }}>
+                        <button onClick={() => close(true)}>Confirm (true)</button>
+                        <button onClick={() => close(false)}>Cancel (false)</button>
+                      </div>
+                    </div>
+                  </Modal>
+                );
+              },
+              { overlayId, defaultValue: 'dismissed' }
+            );
+            setResult(String(value));
+          }}
+        >
+          open dialog
+        </button>
+        <button
+          onClick={() => overlay.close(overlayId)}
+          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
+        >
+          Close Externally
+        </button>
+        <button
+          onClick={() => overlay.closeAll()}
+          style={{ backgroundColor: '#ffa94d', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
+        >
+          Close All
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DemoExternalClose() {
+  const [result, setResult] = useState<string>('(no result yet)');
+  const [status, setStatus] = useState<'idle' | 'waiting'>('idle');
+  const [overlayId] = useState('external-close-demo-overlay');
+
+  return (
+    <div>
+      <h2>5. Demo: External Close WITHOUT defaultValue (Promise stays pending)</h2>
+      <p style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
+        Without <code>defaultValue</code>, the Promise never resolves when closed externally.
+      </p>
+      <p>
+        Result: <strong>{result}</strong>
+      </p>
+      <p>
+        Status: <strong style={{ color: status === 'waiting' ? 'orange' : 'green' }}>{status}</strong>
+      </p>
+      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
+        <button
+          onClick={async () => {
+            setResult('(no result yet)');
+            setStatus('waiting');
+            const value = await overlay.openAsync<boolean>(
+              ({ isOpen, close, unmount }) => {
+                return (
+                  <Modal isOpen={isOpen} onExit={unmount}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 10,
+                      }}
+                    >
+                      <p>Click "Close Externally" - Promise will stay pending!</p>
+                      <button onClick={() => close(true)}>Close Internally (resolves)</button>
+                    </div>
+                  </Modal>
+                );
+              },
+              { overlayId }
+            );
+            setResult(String(value));
+            setStatus('idle');
+          }}
+        >
+          open dialog
+        </button>
+        <button
+          onClick={() => overlay.close(overlayId)}
+          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
+        >
+          Close Externally (Promise stays pending)
+        </button>
+      </div>
     </div>
   );
 }

--- a/examples/react-16/framer-motion/src/demo.tsx
+++ b/examples/react-16/framer-motion/src/demo.tsx
@@ -13,7 +13,7 @@ export function Demo() {
       <hr style={{ margin: '20px 0' }} />
       <DemoOpenAsyncBasic />
       <hr style={{ margin: '20px 0' }} />
-      <DemoOpenAsyncWithOnDismiss />
+      <DemoOpenAsyncWithDefaultValue />
       <hr style={{ margin: '20px 0' }} />
       <DemoExternalClose />
     </div>
@@ -105,15 +105,17 @@ function DemoOpenAsyncBasic() {
   );
 }
 
-function DemoOpenAsyncWithOnDismiss() {
+function DemoOpenAsyncWithDefaultValue() {
   const [result, setResult] = useState<string>('(no result yet)');
-  const [overlayId] = useState('ondismiss-demo-overlay');
+  const [overlayId] = useState('defaultvalue-demo-overlay');
 
   return (
     <div>
       <h2>4. Demo with overlay.openAsync + defaultValue option</h2>
       <p style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
         With <code>defaultValue</code>, the Promise resolves even when closed externally.
+        <br />
+        <code>defaultValue: false</code> → external close resolves with <code>false</code>
       </p>
       <p>
         Result: <strong>{result}</strong>
@@ -122,7 +124,7 @@ function DemoOpenAsyncWithOnDismiss() {
         <button
           onClick={async () => {
             setResult('(waiting...)');
-            const value = await overlay.openAsync<boolean | 'dismissed'>(
+            const value = await overlay.openAsync<boolean>(
               ({ isOpen, close, unmount }) => {
                 return (
                   <Modal isOpen={isOpen} onExit={unmount}>
@@ -145,7 +147,7 @@ function DemoOpenAsyncWithOnDismiss() {
                   </Modal>
                 );
               },
-              { overlayId, defaultValue: 'dismissed' }
+              { overlayId, defaultValue: false }
             );
             setResult(String(value));
           }}
@@ -156,13 +158,13 @@ function DemoOpenAsyncWithOnDismiss() {
           onClick={() => overlay.close(overlayId)}
           style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
         >
-          Close Externally
+          Close Externally (→ false)
         </button>
         <button
           onClick={() => overlay.closeAll()}
           style={{ backgroundColor: '#ffa94d', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
         >
-          Close All
+          Close All (→ false)
         </button>
       </div>
     </div>

--- a/examples/react-17/framer-motion/src/demo.tsx
+++ b/examples/react-17/framer-motion/src/demo.tsx
@@ -107,7 +107,7 @@ function DemoOpenAsyncBasic() {
 
 function DemoOpenAsyncWithDefaultValue() {
   const [result, setResult] = useState<string>('(no result yet)');
-  const [overlayId] = useState('defaultvalue-demo-overlay');
+  const overlayId = 'defaultvalue-demo-overlay';
 
   return (
     <div>
@@ -120,53 +120,66 @@ function DemoOpenAsyncWithDefaultValue() {
       <p>
         Result: <strong>{result}</strong>
       </p>
-      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
-        <button
-          onClick={async () => {
-            setResult('(waiting...)');
-            const value = await overlay.openAsync<boolean>(
-              ({ isOpen, close, unmount }) => {
-                return (
-                  <Modal isOpen={isOpen} onExit={unmount}>
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        gap: 10,
-                      }}
-                    >
-                      <p>Do you confirm?</p>
-                      <p style={{ fontSize: 12, color: '#666' }}>(Try clicking "Close Externally" button below)</p>
-                      <div style={{ display: 'flex', gap: 10 }}>
-                        <button onClick={() => close(true)}>Confirm (true)</button>
-                        <button onClick={() => close(false)}>Cancel (false)</button>
-                      </div>
+      <button
+        onClick={async () => {
+          setResult('(waiting...)');
+          const value = await overlay.openAsync<boolean>(
+            ({ isOpen, close, unmount }) => {
+              return (
+                <Modal isOpen={isOpen} onExit={unmount}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 10,
+                    }}
+                  >
+                    <p>Do you confirm?</p>
+                    <div style={{ display: 'flex', gap: 10 }}>
+                      <button onClick={() => close(true)}>Confirm (true)</button>
+                      <button onClick={() => close(false)}>Cancel (false)</button>
                     </div>
-                  </Modal>
-                );
-              },
-              { overlayId, defaultValue: false }
-            );
-            setResult(String(value));
-          }}
-        >
-          open dialog
-        </button>
-        <button
-          onClick={() => overlay.close(overlayId)}
-          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
-        >
-          Close Externally (→ false)
-        </button>
-        <button
-          onClick={() => overlay.closeAll()}
-          style={{ backgroundColor: '#ffa94d', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
-        >
-          Close All (→ false)
-        </button>
-      </div>
+                    <hr style={{ width: '100%', margin: '10px 0' }} />
+                    <p style={{ fontSize: 12, color: '#666' }}>External close (uses overlay.close):</p>
+                    <div style={{ display: 'flex', gap: 10 }}>
+                      <button
+                        onClick={() => overlay.close(overlayId)}
+                        style={{
+                          backgroundColor: '#ff6b6b',
+                          color: 'white',
+                          border: 'none',
+                          padding: '8px 16px',
+                          borderRadius: 4,
+                        }}
+                      >
+                        overlay.close() → false
+                      </button>
+                      <button
+                        onClick={() => overlay.closeAll()}
+                        style={{
+                          backgroundColor: '#ffa94d',
+                          color: 'white',
+                          border: 'none',
+                          padding: '8px 16px',
+                          borderRadius: 4,
+                        }}
+                      >
+                        overlay.closeAll() → false
+                      </button>
+                    </div>
+                  </div>
+                </Modal>
+              );
+            },
+            { overlayId, defaultValue: false }
+          );
+          setResult(String(value));
+        }}
+      >
+        open dialog
+      </button>
     </div>
   );
 }
@@ -174,7 +187,7 @@ function DemoOpenAsyncWithDefaultValue() {
 function DemoExternalClose() {
   const [result, setResult] = useState<string>('(no result yet)');
   const [status, setStatus] = useState<'idle' | 'waiting'>('idle');
-  const [overlayId] = useState('external-close-demo-overlay');
+  const overlayId = 'external-close-demo-overlay';
 
   return (
     <div>
@@ -188,45 +201,51 @@ function DemoExternalClose() {
       <p>
         Status: <strong style={{ color: status === 'waiting' ? 'orange' : 'green' }}>{status}</strong>
       </p>
-      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
-        <button
-          onClick={async () => {
-            setResult('(no result yet)');
-            setStatus('waiting');
-            const value = await overlay.openAsync<boolean>(
-              ({ isOpen, close, unmount }) => {
-                return (
-                  <Modal isOpen={isOpen} onExit={unmount}>
-                    <div
+      <button
+        onClick={async () => {
+          setResult('(no result yet)');
+          setStatus('waiting');
+          const value = await overlay.openAsync<boolean>(
+            ({ isOpen, close, unmount }) => {
+              return (
+                <Modal isOpen={isOpen} onExit={unmount}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 10,
+                    }}
+                  >
+                    <p>Without defaultValue, external close keeps Promise pending</p>
+                    <button onClick={() => close(true)}>close(true) - resolves</button>
+                    <hr style={{ width: '100%', margin: '10px 0' }} />
+                    <p style={{ fontSize: 12, color: '#666' }}>External close (Promise stays pending!):</p>
+                    <button
+                      onClick={() => overlay.close(overlayId)}
                       style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        gap: 10,
+                        backgroundColor: '#ff6b6b',
+                        color: 'white',
+                        border: 'none',
+                        padding: '8px 16px',
+                        borderRadius: 4,
                       }}
                     >
-                      <p>Click "Close Externally" - Promise will stay pending!</p>
-                      <button onClick={() => close(true)}>Close Internally (resolves)</button>
-                    </div>
-                  </Modal>
-                );
-              },
-              { overlayId }
-            );
-            setResult(String(value));
-            setStatus('idle');
-          }}
-        >
-          open dialog
-        </button>
-        <button
-          onClick={() => overlay.close(overlayId)}
-          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
-        >
-          Close Externally (Promise stays pending)
-        </button>
-      </div>
+                      overlay.close() - NO resolve
+                    </button>
+                  </div>
+                </Modal>
+              );
+            },
+            { overlayId }
+          );
+          setResult(String(value));
+          setStatus('idle');
+        }}
+      >
+        open dialog
+      </button>
     </div>
   );
 }

--- a/examples/react-17/framer-motion/src/demo.tsx
+++ b/examples/react-17/framer-motion/src/demo.tsx
@@ -4,9 +4,18 @@ import { Modal } from './components/modal.tsx';
 
 export function Demo() {
   return (
-    <div>
+    <div style={{ padding: 20, fontFamily: 'system-ui, sans-serif' }}>
+      <h1>overlay-kit Examples</h1>
+      <hr style={{ margin: '20px 0' }} />
       <DemoWithState />
+      <hr style={{ margin: '20px 0' }} />
       <DemoWithEsOverlay />
+      <hr style={{ margin: '20px 0' }} />
+      <DemoOpenAsyncBasic />
+      <hr style={{ margin: '20px 0' }} />
+      <DemoOpenAsyncWithOnDismiss />
+      <hr style={{ margin: '20px 0' }} />
+      <DemoExternalClose />
     </div>
   );
 }
@@ -16,7 +25,7 @@ function DemoWithState() {
 
   return (
     <div>
-      <p>Demo with useState</p>
+      <h2>1. Demo with useState</h2>
       <button onClick={() => setIsOpen(true)}>open modal</button>
       <Modal isOpen={isOpen}>
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
@@ -31,7 +40,7 @@ function DemoWithState() {
 function DemoWithEsOverlay() {
   return (
     <div>
-      <p>Demo with overlay-kit</p>
+      <h2>2. Demo with overlay.open</h2>
       <button
         onClick={() => {
           overlay.open(({ isOpen, close, unmount }) => {
@@ -50,6 +59,172 @@ function DemoWithEsOverlay() {
       >
         open modal
       </button>
+    </div>
+  );
+}
+
+function DemoOpenAsyncBasic() {
+  const [result, setResult] = useState<string>('(no result yet)');
+
+  return (
+    <div>
+      <h2>3. Demo with overlay.openAsync (basic)</h2>
+      <p>
+        Result: <strong>{result}</strong>
+      </p>
+      <button
+        onClick={async () => {
+          setResult('(waiting...)');
+          const value = await overlay.openAsync<boolean>(({ isOpen, close, unmount }) => {
+            return (
+              <Modal isOpen={isOpen} onExit={unmount}>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: 10,
+                  }}
+                >
+                  <p>Do you confirm?</p>
+                  <div style={{ display: 'flex', gap: 10 }}>
+                    <button onClick={() => close(true)}>Confirm (true)</button>
+                    <button onClick={() => close(false)}>Cancel (false)</button>
+                  </div>
+                </div>
+              </Modal>
+            );
+          });
+          setResult(String(value));
+        }}
+      >
+        open confirm dialog
+      </button>
+    </div>
+  );
+}
+
+function DemoOpenAsyncWithOnDismiss() {
+  const [result, setResult] = useState<string>('(no result yet)');
+  const [overlayId] = useState('ondismiss-demo-overlay');
+
+  return (
+    <div>
+      <h2>4. Demo with overlay.openAsync + defaultValue option</h2>
+      <p style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
+        With <code>defaultValue</code>, the Promise resolves even when closed externally.
+      </p>
+      <p>
+        Result: <strong>{result}</strong>
+      </p>
+      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
+        <button
+          onClick={async () => {
+            setResult('(waiting...)');
+            const value = await overlay.openAsync<boolean | 'dismissed'>(
+              ({ isOpen, close, unmount }) => {
+                return (
+                  <Modal isOpen={isOpen} onExit={unmount}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 10,
+                      }}
+                    >
+                      <p>Do you confirm?</p>
+                      <p style={{ fontSize: 12, color: '#666' }}>(Try clicking "Close Externally" button below)</p>
+                      <div style={{ display: 'flex', gap: 10 }}>
+                        <button onClick={() => close(true)}>Confirm (true)</button>
+                        <button onClick={() => close(false)}>Cancel (false)</button>
+                      </div>
+                    </div>
+                  </Modal>
+                );
+              },
+              { overlayId, defaultValue: 'dismissed' }
+            );
+            setResult(String(value));
+          }}
+        >
+          open dialog
+        </button>
+        <button
+          onClick={() => overlay.close(overlayId)}
+          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
+        >
+          Close Externally
+        </button>
+        <button
+          onClick={() => overlay.closeAll()}
+          style={{ backgroundColor: '#ffa94d', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
+        >
+          Close All
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DemoExternalClose() {
+  const [result, setResult] = useState<string>('(no result yet)');
+  const [status, setStatus] = useState<'idle' | 'waiting'>('idle');
+  const [overlayId] = useState('external-close-demo-overlay');
+
+  return (
+    <div>
+      <h2>5. Demo: External Close WITHOUT defaultValue (Promise stays pending)</h2>
+      <p style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
+        Without <code>defaultValue</code>, the Promise never resolves when closed externally.
+      </p>
+      <p>
+        Result: <strong>{result}</strong>
+      </p>
+      <p>
+        Status: <strong style={{ color: status === 'waiting' ? 'orange' : 'green' }}>{status}</strong>
+      </p>
+      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
+        <button
+          onClick={async () => {
+            setResult('(no result yet)');
+            setStatus('waiting');
+            const value = await overlay.openAsync<boolean>(
+              ({ isOpen, close, unmount }) => {
+                return (
+                  <Modal isOpen={isOpen} onExit={unmount}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 10,
+                      }}
+                    >
+                      <p>Click "Close Externally" - Promise will stay pending!</p>
+                      <button onClick={() => close(true)}>Close Internally (resolves)</button>
+                    </div>
+                  </Modal>
+                );
+              },
+              { overlayId }
+            );
+            setResult(String(value));
+            setStatus('idle');
+          }}
+        >
+          open dialog
+        </button>
+        <button
+          onClick={() => overlay.close(overlayId)}
+          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
+        >
+          Close Externally (Promise stays pending)
+        </button>
+      </div>
     </div>
   );
 }

--- a/examples/react-17/framer-motion/src/demo.tsx
+++ b/examples/react-17/framer-motion/src/demo.tsx
@@ -13,7 +13,7 @@ export function Demo() {
       <hr style={{ margin: '20px 0' }} />
       <DemoOpenAsyncBasic />
       <hr style={{ margin: '20px 0' }} />
-      <DemoOpenAsyncWithOnDismiss />
+      <DemoOpenAsyncWithDefaultValue />
       <hr style={{ margin: '20px 0' }} />
       <DemoExternalClose />
     </div>
@@ -105,15 +105,17 @@ function DemoOpenAsyncBasic() {
   );
 }
 
-function DemoOpenAsyncWithOnDismiss() {
+function DemoOpenAsyncWithDefaultValue() {
   const [result, setResult] = useState<string>('(no result yet)');
-  const [overlayId] = useState('ondismiss-demo-overlay');
+  const [overlayId] = useState('defaultvalue-demo-overlay');
 
   return (
     <div>
       <h2>4. Demo with overlay.openAsync + defaultValue option</h2>
       <p style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
         With <code>defaultValue</code>, the Promise resolves even when closed externally.
+        <br />
+        <code>defaultValue: false</code> → external close resolves with <code>false</code>
       </p>
       <p>
         Result: <strong>{result}</strong>
@@ -122,7 +124,7 @@ function DemoOpenAsyncWithOnDismiss() {
         <button
           onClick={async () => {
             setResult('(waiting...)');
-            const value = await overlay.openAsync<boolean | 'dismissed'>(
+            const value = await overlay.openAsync<boolean>(
               ({ isOpen, close, unmount }) => {
                 return (
                   <Modal isOpen={isOpen} onExit={unmount}>
@@ -145,7 +147,7 @@ function DemoOpenAsyncWithOnDismiss() {
                   </Modal>
                 );
               },
-              { overlayId, defaultValue: 'dismissed' }
+              { overlayId, defaultValue: false }
             );
             setResult(String(value));
           }}
@@ -156,13 +158,13 @@ function DemoOpenAsyncWithOnDismiss() {
           onClick={() => overlay.close(overlayId)}
           style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
         >
-          Close Externally
+          Close Externally (→ false)
         </button>
         <button
           onClick={() => overlay.closeAll()}
           style={{ backgroundColor: '#ffa94d', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
         >
-          Close All
+          Close All (→ false)
         </button>
       </div>
     </div>

--- a/examples/react-18/framer-motion/src/demo.tsx
+++ b/examples/react-18/framer-motion/src/demo.tsx
@@ -107,7 +107,7 @@ function DemoOpenAsyncBasic() {
 
 function DemoOpenAsyncWithDefaultValue() {
   const [result, setResult] = useState<string>('(no result yet)');
-  const [overlayId] = useState('defaultvalue-demo-overlay');
+  const overlayId = 'defaultvalue-demo-overlay';
 
   return (
     <div>
@@ -120,53 +120,66 @@ function DemoOpenAsyncWithDefaultValue() {
       <p>
         Result: <strong>{result}</strong>
       </p>
-      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
-        <button
-          onClick={async () => {
-            setResult('(waiting...)');
-            const value = await overlay.openAsync<boolean>(
-              ({ isOpen, close, unmount }) => {
-                return (
-                  <Modal isOpen={isOpen} onExit={unmount}>
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        gap: 10,
-                      }}
-                    >
-                      <p>Do you confirm?</p>
-                      <p style={{ fontSize: 12, color: '#666' }}>(Try clicking "Close Externally" button below)</p>
-                      <div style={{ display: 'flex', gap: 10 }}>
-                        <button onClick={() => close(true)}>Confirm (true)</button>
-                        <button onClick={() => close(false)}>Cancel (false)</button>
-                      </div>
+      <button
+        onClick={async () => {
+          setResult('(waiting...)');
+          const value = await overlay.openAsync<boolean>(
+            ({ isOpen, close, unmount }) => {
+              return (
+                <Modal isOpen={isOpen} onExit={unmount}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 10,
+                    }}
+                  >
+                    <p>Do you confirm?</p>
+                    <div style={{ display: 'flex', gap: 10 }}>
+                      <button onClick={() => close(true)}>Confirm (true)</button>
+                      <button onClick={() => close(false)}>Cancel (false)</button>
                     </div>
-                  </Modal>
-                );
-              },
-              { overlayId, defaultValue: false }
-            );
-            setResult(String(value));
-          }}
-        >
-          open dialog
-        </button>
-        <button
-          onClick={() => overlay.close(overlayId)}
-          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
-        >
-          Close Externally (→ false)
-        </button>
-        <button
-          onClick={() => overlay.closeAll()}
-          style={{ backgroundColor: '#ffa94d', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
-        >
-          Close All (→ false)
-        </button>
-      </div>
+                    <hr style={{ width: '100%', margin: '10px 0' }} />
+                    <p style={{ fontSize: 12, color: '#666' }}>External close (uses overlay.close):</p>
+                    <div style={{ display: 'flex', gap: 10 }}>
+                      <button
+                        onClick={() => overlay.close(overlayId)}
+                        style={{
+                          backgroundColor: '#ff6b6b',
+                          color: 'white',
+                          border: 'none',
+                          padding: '8px 16px',
+                          borderRadius: 4,
+                        }}
+                      >
+                        overlay.close() → false
+                      </button>
+                      <button
+                        onClick={() => overlay.closeAll()}
+                        style={{
+                          backgroundColor: '#ffa94d',
+                          color: 'white',
+                          border: 'none',
+                          padding: '8px 16px',
+                          borderRadius: 4,
+                        }}
+                      >
+                        overlay.closeAll() → false
+                      </button>
+                    </div>
+                  </div>
+                </Modal>
+              );
+            },
+            { overlayId, defaultValue: false }
+          );
+          setResult(String(value));
+        }}
+      >
+        open dialog
+      </button>
     </div>
   );
 }
@@ -174,7 +187,7 @@ function DemoOpenAsyncWithDefaultValue() {
 function DemoExternalClose() {
   const [result, setResult] = useState<string>('(no result yet)');
   const [status, setStatus] = useState<'idle' | 'waiting'>('idle');
-  const [overlayId] = useState('external-close-demo-overlay');
+  const overlayId = 'external-close-demo-overlay';
 
   return (
     <div>
@@ -188,45 +201,51 @@ function DemoExternalClose() {
       <p>
         Status: <strong style={{ color: status === 'waiting' ? 'orange' : 'green' }}>{status}</strong>
       </p>
-      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
-        <button
-          onClick={async () => {
-            setResult('(no result yet)');
-            setStatus('waiting');
-            const value = await overlay.openAsync<boolean>(
-              ({ isOpen, close, unmount }) => {
-                return (
-                  <Modal isOpen={isOpen} onExit={unmount}>
-                    <div
+      <button
+        onClick={async () => {
+          setResult('(no result yet)');
+          setStatus('waiting');
+          const value = await overlay.openAsync<boolean>(
+            ({ isOpen, close, unmount }) => {
+              return (
+                <Modal isOpen={isOpen} onExit={unmount}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 10,
+                    }}
+                  >
+                    <p>Without defaultValue, external close keeps Promise pending</p>
+                    <button onClick={() => close(true)}>close(true) - resolves</button>
+                    <hr style={{ width: '100%', margin: '10px 0' }} />
+                    <p style={{ fontSize: 12, color: '#666' }}>External close (Promise stays pending!):</p>
+                    <button
+                      onClick={() => overlay.close(overlayId)}
                       style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        gap: 10,
+                        backgroundColor: '#ff6b6b',
+                        color: 'white',
+                        border: 'none',
+                        padding: '8px 16px',
+                        borderRadius: 4,
                       }}
                     >
-                      <p>Click "Close Externally" - Promise will stay pending!</p>
-                      <button onClick={() => close(true)}>Close Internally (resolves)</button>
-                    </div>
-                  </Modal>
-                );
-              },
-              { overlayId }
-            );
-            setResult(String(value));
-            setStatus('idle');
-          }}
-        >
-          open dialog
-        </button>
-        <button
-          onClick={() => overlay.close(overlayId)}
-          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
-        >
-          Close Externally (Promise stays pending)
-        </button>
-      </div>
+                      overlay.close() - NO resolve
+                    </button>
+                  </div>
+                </Modal>
+              );
+            },
+            { overlayId }
+          );
+          setResult(String(value));
+          setStatus('idle');
+        }}
+      >
+        open dialog
+      </button>
     </div>
   );
 }

--- a/examples/react-18/framer-motion/src/demo.tsx
+++ b/examples/react-18/framer-motion/src/demo.tsx
@@ -4,9 +4,18 @@ import { Modal } from './components/modal.tsx';
 
 export function Demo() {
   return (
-    <div>
+    <div style={{ padding: 20, fontFamily: 'system-ui, sans-serif' }}>
+      <h1>overlay-kit Examples</h1>
+      <hr style={{ margin: '20px 0' }} />
       <DemoWithState />
+      <hr style={{ margin: '20px 0' }} />
       <DemoWithEsOverlay />
+      <hr style={{ margin: '20px 0' }} />
+      <DemoOpenAsyncBasic />
+      <hr style={{ margin: '20px 0' }} />
+      <DemoOpenAsyncWithOnDismiss />
+      <hr style={{ margin: '20px 0' }} />
+      <DemoExternalClose />
     </div>
   );
 }
@@ -16,7 +25,7 @@ function DemoWithState() {
 
   return (
     <div>
-      <p>Demo with useState</p>
+      <h2>1. Demo with useState</h2>
       <button onClick={() => setIsOpen(true)}>open modal</button>
       <Modal isOpen={isOpen}>
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
@@ -31,7 +40,7 @@ function DemoWithState() {
 function DemoWithEsOverlay() {
   return (
     <div>
-      <p>Demo with overlay-kit</p>
+      <h2>2. Demo with overlay.open</h2>
       <button
         onClick={() => {
           overlay.open(({ isOpen, close, unmount }) => {
@@ -50,6 +59,172 @@ function DemoWithEsOverlay() {
       >
         open modal
       </button>
+    </div>
+  );
+}
+
+function DemoOpenAsyncBasic() {
+  const [result, setResult] = useState<string>('(no result yet)');
+
+  return (
+    <div>
+      <h2>3. Demo with overlay.openAsync (basic)</h2>
+      <p>
+        Result: <strong>{result}</strong>
+      </p>
+      <button
+        onClick={async () => {
+          setResult('(waiting...)');
+          const value = await overlay.openAsync<boolean>(({ isOpen, close, unmount }) => {
+            return (
+              <Modal isOpen={isOpen} onExit={unmount}>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: 10,
+                  }}
+                >
+                  <p>Do you confirm?</p>
+                  <div style={{ display: 'flex', gap: 10 }}>
+                    <button onClick={() => close(true)}>Confirm (true)</button>
+                    <button onClick={() => close(false)}>Cancel (false)</button>
+                  </div>
+                </div>
+              </Modal>
+            );
+          });
+          setResult(String(value));
+        }}
+      >
+        open confirm dialog
+      </button>
+    </div>
+  );
+}
+
+function DemoOpenAsyncWithOnDismiss() {
+  const [result, setResult] = useState<string>('(no result yet)');
+  const [overlayId] = useState('ondismiss-demo-overlay');
+
+  return (
+    <div>
+      <h2>4. Demo with overlay.openAsync + defaultValue option</h2>
+      <p style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
+        With <code>defaultValue</code>, the Promise resolves even when closed externally.
+      </p>
+      <p>
+        Result: <strong>{result}</strong>
+      </p>
+      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
+        <button
+          onClick={async () => {
+            setResult('(waiting...)');
+            const value = await overlay.openAsync<boolean | 'dismissed'>(
+              ({ isOpen, close, unmount }) => {
+                return (
+                  <Modal isOpen={isOpen} onExit={unmount}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 10,
+                      }}
+                    >
+                      <p>Do you confirm?</p>
+                      <p style={{ fontSize: 12, color: '#666' }}>(Try clicking "Close Externally" button below)</p>
+                      <div style={{ display: 'flex', gap: 10 }}>
+                        <button onClick={() => close(true)}>Confirm (true)</button>
+                        <button onClick={() => close(false)}>Cancel (false)</button>
+                      </div>
+                    </div>
+                  </Modal>
+                );
+              },
+              { overlayId, defaultValue: 'dismissed' }
+            );
+            setResult(String(value));
+          }}
+        >
+          open dialog
+        </button>
+        <button
+          onClick={() => overlay.close(overlayId)}
+          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
+        >
+          Close Externally
+        </button>
+        <button
+          onClick={() => overlay.closeAll()}
+          style={{ backgroundColor: '#ffa94d', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
+        >
+          Close All
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DemoExternalClose() {
+  const [result, setResult] = useState<string>('(no result yet)');
+  const [status, setStatus] = useState<'idle' | 'waiting'>('idle');
+  const [overlayId] = useState('external-close-demo-overlay');
+
+  return (
+    <div>
+      <h2>5. Demo: External Close WITHOUT defaultValue (Promise stays pending)</h2>
+      <p style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
+        Without <code>defaultValue</code>, the Promise never resolves when closed externally.
+      </p>
+      <p>
+        Result: <strong>{result}</strong>
+      </p>
+      <p>
+        Status: <strong style={{ color: status === 'waiting' ? 'orange' : 'green' }}>{status}</strong>
+      </p>
+      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
+        <button
+          onClick={async () => {
+            setResult('(no result yet)');
+            setStatus('waiting');
+            const value = await overlay.openAsync<boolean>(
+              ({ isOpen, close, unmount }) => {
+                return (
+                  <Modal isOpen={isOpen} onExit={unmount}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 10,
+                      }}
+                    >
+                      <p>Click "Close Externally" - Promise will stay pending!</p>
+                      <button onClick={() => close(true)}>Close Internally (resolves)</button>
+                    </div>
+                  </Modal>
+                );
+              },
+              { overlayId }
+            );
+            setResult(String(value));
+            setStatus('idle');
+          }}
+        >
+          open dialog
+        </button>
+        <button
+          onClick={() => overlay.close(overlayId)}
+          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
+        >
+          Close Externally (Promise stays pending)
+        </button>
+      </div>
     </div>
   );
 }

--- a/examples/react-18/framer-motion/src/demo.tsx
+++ b/examples/react-18/framer-motion/src/demo.tsx
@@ -13,7 +13,7 @@ export function Demo() {
       <hr style={{ margin: '20px 0' }} />
       <DemoOpenAsyncBasic />
       <hr style={{ margin: '20px 0' }} />
-      <DemoOpenAsyncWithOnDismiss />
+      <DemoOpenAsyncWithDefaultValue />
       <hr style={{ margin: '20px 0' }} />
       <DemoExternalClose />
     </div>
@@ -105,15 +105,17 @@ function DemoOpenAsyncBasic() {
   );
 }
 
-function DemoOpenAsyncWithOnDismiss() {
+function DemoOpenAsyncWithDefaultValue() {
   const [result, setResult] = useState<string>('(no result yet)');
-  const [overlayId] = useState('ondismiss-demo-overlay');
+  const [overlayId] = useState('defaultvalue-demo-overlay');
 
   return (
     <div>
       <h2>4. Demo with overlay.openAsync + defaultValue option</h2>
       <p style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
         With <code>defaultValue</code>, the Promise resolves even when closed externally.
+        <br />
+        <code>defaultValue: false</code> → external close resolves with <code>false</code>
       </p>
       <p>
         Result: <strong>{result}</strong>
@@ -122,7 +124,7 @@ function DemoOpenAsyncWithOnDismiss() {
         <button
           onClick={async () => {
             setResult('(waiting...)');
-            const value = await overlay.openAsync<boolean | 'dismissed'>(
+            const value = await overlay.openAsync<boolean>(
               ({ isOpen, close, unmount }) => {
                 return (
                   <Modal isOpen={isOpen} onExit={unmount}>
@@ -145,7 +147,7 @@ function DemoOpenAsyncWithOnDismiss() {
                   </Modal>
                 );
               },
-              { overlayId, defaultValue: 'dismissed' }
+              { overlayId, defaultValue: false }
             );
             setResult(String(value));
           }}
@@ -156,13 +158,13 @@ function DemoOpenAsyncWithOnDismiss() {
           onClick={() => overlay.close(overlayId)}
           style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
         >
-          Close Externally
+          Close Externally (→ false)
         </button>
         <button
           onClick={() => overlay.closeAll()}
           style={{ backgroundColor: '#ffa94d', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
         >
-          Close All
+          Close All (→ false)
         </button>
       </div>
     </div>

--- a/examples/react-19/framer-motion/src/demo.tsx
+++ b/examples/react-19/framer-motion/src/demo.tsx
@@ -107,7 +107,7 @@ function DemoOpenAsyncBasic() {
 
 function DemoOpenAsyncWithDefaultValue() {
   const [result, setResult] = useState<string>('(no result yet)');
-  const [overlayId] = useState('defaultvalue-demo-overlay');
+  const overlayId = 'defaultvalue-demo-overlay';
 
   return (
     <div>
@@ -120,53 +120,66 @@ function DemoOpenAsyncWithDefaultValue() {
       <p>
         Result: <strong>{result}</strong>
       </p>
-      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
-        <button
-          onClick={async () => {
-            setResult('(waiting...)');
-            const value = await overlay.openAsync<boolean>(
-              ({ isOpen, close, unmount }) => {
-                return (
-                  <Modal isOpen={isOpen} onExit={unmount}>
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        gap: 10,
-                      }}
-                    >
-                      <p>Do you confirm?</p>
-                      <p style={{ fontSize: 12, color: '#666' }}>(Try clicking "Close Externally" button below)</p>
-                      <div style={{ display: 'flex', gap: 10 }}>
-                        <button onClick={() => close(true)}>Confirm (true)</button>
-                        <button onClick={() => close(false)}>Cancel (false)</button>
-                      </div>
+      <button
+        onClick={async () => {
+          setResult('(waiting...)');
+          const value = await overlay.openAsync<boolean>(
+            ({ isOpen, close, unmount }) => {
+              return (
+                <Modal isOpen={isOpen} onExit={unmount}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 10,
+                    }}
+                  >
+                    <p>Do you confirm?</p>
+                    <div style={{ display: 'flex', gap: 10 }}>
+                      <button onClick={() => close(true)}>Confirm (true)</button>
+                      <button onClick={() => close(false)}>Cancel (false)</button>
                     </div>
-                  </Modal>
-                );
-              },
-              { overlayId, defaultValue: false }
-            );
-            setResult(String(value));
-          }}
-        >
-          open dialog
-        </button>
-        <button
-          onClick={() => overlay.close(overlayId)}
-          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
-        >
-          Close Externally (→ false)
-        </button>
-        <button
-          onClick={() => overlay.closeAll()}
-          style={{ backgroundColor: '#ffa94d', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
-        >
-          Close All (→ false)
-        </button>
-      </div>
+                    <hr style={{ width: '100%', margin: '10px 0' }} />
+                    <p style={{ fontSize: 12, color: '#666' }}>External close (uses overlay.close):</p>
+                    <div style={{ display: 'flex', gap: 10 }}>
+                      <button
+                        onClick={() => overlay.close(overlayId)}
+                        style={{
+                          backgroundColor: '#ff6b6b',
+                          color: 'white',
+                          border: 'none',
+                          padding: '8px 16px',
+                          borderRadius: 4,
+                        }}
+                      >
+                        overlay.close() → false
+                      </button>
+                      <button
+                        onClick={() => overlay.closeAll()}
+                        style={{
+                          backgroundColor: '#ffa94d',
+                          color: 'white',
+                          border: 'none',
+                          padding: '8px 16px',
+                          borderRadius: 4,
+                        }}
+                      >
+                        overlay.closeAll() → false
+                      </button>
+                    </div>
+                  </div>
+                </Modal>
+              );
+            },
+            { overlayId, defaultValue: false }
+          );
+          setResult(String(value));
+        }}
+      >
+        open dialog
+      </button>
     </div>
   );
 }
@@ -174,7 +187,7 @@ function DemoOpenAsyncWithDefaultValue() {
 function DemoExternalClose() {
   const [result, setResult] = useState<string>('(no result yet)');
   const [status, setStatus] = useState<'idle' | 'waiting'>('idle');
-  const [overlayId] = useState('external-close-demo-overlay');
+  const overlayId = 'external-close-demo-overlay';
 
   return (
     <div>
@@ -188,45 +201,51 @@ function DemoExternalClose() {
       <p>
         Status: <strong style={{ color: status === 'waiting' ? 'orange' : 'green' }}>{status}</strong>
       </p>
-      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
-        <button
-          onClick={async () => {
-            setResult('(no result yet)');
-            setStatus('waiting');
-            const value = await overlay.openAsync<boolean>(
-              ({ isOpen, close, unmount }) => {
-                return (
-                  <Modal isOpen={isOpen} onExit={unmount}>
-                    <div
+      <button
+        onClick={async () => {
+          setResult('(no result yet)');
+          setStatus('waiting');
+          const value = await overlay.openAsync<boolean>(
+            ({ isOpen, close, unmount }) => {
+              return (
+                <Modal isOpen={isOpen} onExit={unmount}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 10,
+                    }}
+                  >
+                    <p>Without defaultValue, external close keeps Promise pending</p>
+                    <button onClick={() => close(true)}>close(true) - resolves</button>
+                    <hr style={{ width: '100%', margin: '10px 0' }} />
+                    <p style={{ fontSize: 12, color: '#666' }}>External close (Promise stays pending!):</p>
+                    <button
+                      onClick={() => overlay.close(overlayId)}
                       style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        gap: 10,
+                        backgroundColor: '#ff6b6b',
+                        color: 'white',
+                        border: 'none',
+                        padding: '8px 16px',
+                        borderRadius: 4,
                       }}
                     >
-                      <p>Click "Close Externally" - Promise will stay pending!</p>
-                      <button onClick={() => close(true)}>Close Internally (resolves)</button>
-                    </div>
-                  </Modal>
-                );
-              },
-              { overlayId }
-            );
-            setResult(String(value));
-            setStatus('idle');
-          }}
-        >
-          open dialog
-        </button>
-        <button
-          onClick={() => overlay.close(overlayId)}
-          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
-        >
-          Close Externally (Promise stays pending)
-        </button>
-      </div>
+                      overlay.close() - NO resolve
+                    </button>
+                  </div>
+                </Modal>
+              );
+            },
+            { overlayId }
+          );
+          setResult(String(value));
+          setStatus('idle');
+        }}
+      >
+        open dialog
+      </button>
     </div>
   );
 }

--- a/examples/react-19/framer-motion/src/demo.tsx
+++ b/examples/react-19/framer-motion/src/demo.tsx
@@ -4,9 +4,18 @@ import { Modal } from './components/modal.tsx';
 
 export function Demo() {
   return (
-    <div>
+    <div style={{ padding: 20, fontFamily: 'system-ui, sans-serif' }}>
+      <h1>overlay-kit Examples</h1>
+      <hr style={{ margin: '20px 0' }} />
       <DemoWithState />
+      <hr style={{ margin: '20px 0' }} />
       <DemoWithEsOverlay />
+      <hr style={{ margin: '20px 0' }} />
+      <DemoOpenAsyncBasic />
+      <hr style={{ margin: '20px 0' }} />
+      <DemoOpenAsyncWithOnDismiss />
+      <hr style={{ margin: '20px 0' }} />
+      <DemoExternalClose />
     </div>
   );
 }
@@ -16,7 +25,7 @@ function DemoWithState() {
 
   return (
     <div>
-      <p>Demo with useState</p>
+      <h2>1. Demo with useState</h2>
       <button onClick={() => setIsOpen(true)}>open modal</button>
       <Modal isOpen={isOpen}>
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
@@ -31,7 +40,7 @@ function DemoWithState() {
 function DemoWithEsOverlay() {
   return (
     <div>
-      <p>Demo with overlay-kit</p>
+      <h2>2. Demo with overlay.open</h2>
       <button
         onClick={() => {
           overlay.open(({ isOpen, close, unmount }) => {
@@ -50,6 +59,172 @@ function DemoWithEsOverlay() {
       >
         open modal
       </button>
+    </div>
+  );
+}
+
+function DemoOpenAsyncBasic() {
+  const [result, setResult] = useState<string>('(no result yet)');
+
+  return (
+    <div>
+      <h2>3. Demo with overlay.openAsync (basic)</h2>
+      <p>
+        Result: <strong>{result}</strong>
+      </p>
+      <button
+        onClick={async () => {
+          setResult('(waiting...)');
+          const value = await overlay.openAsync<boolean>(({ isOpen, close, unmount }) => {
+            return (
+              <Modal isOpen={isOpen} onExit={unmount}>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: 10,
+                  }}
+                >
+                  <p>Do you confirm?</p>
+                  <div style={{ display: 'flex', gap: 10 }}>
+                    <button onClick={() => close(true)}>Confirm (true)</button>
+                    <button onClick={() => close(false)}>Cancel (false)</button>
+                  </div>
+                </div>
+              </Modal>
+            );
+          });
+          setResult(String(value));
+        }}
+      >
+        open confirm dialog
+      </button>
+    </div>
+  );
+}
+
+function DemoOpenAsyncWithOnDismiss() {
+  const [result, setResult] = useState<string>('(no result yet)');
+  const [overlayId] = useState('ondismiss-demo-overlay');
+
+  return (
+    <div>
+      <h2>4. Demo with overlay.openAsync + defaultValue option</h2>
+      <p style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
+        With <code>defaultValue</code>, the Promise resolves even when closed externally.
+      </p>
+      <p>
+        Result: <strong>{result}</strong>
+      </p>
+      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
+        <button
+          onClick={async () => {
+            setResult('(waiting...)');
+            const value = await overlay.openAsync<boolean | 'dismissed'>(
+              ({ isOpen, close, unmount }) => {
+                return (
+                  <Modal isOpen={isOpen} onExit={unmount}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 10,
+                      }}
+                    >
+                      <p>Do you confirm?</p>
+                      <p style={{ fontSize: 12, color: '#666' }}>(Try clicking "Close Externally" button below)</p>
+                      <div style={{ display: 'flex', gap: 10 }}>
+                        <button onClick={() => close(true)}>Confirm (true)</button>
+                        <button onClick={() => close(false)}>Cancel (false)</button>
+                      </div>
+                    </div>
+                  </Modal>
+                );
+              },
+              { overlayId, defaultValue: 'dismissed' }
+            );
+            setResult(String(value));
+          }}
+        >
+          open dialog
+        </button>
+        <button
+          onClick={() => overlay.close(overlayId)}
+          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
+        >
+          Close Externally
+        </button>
+        <button
+          onClick={() => overlay.closeAll()}
+          style={{ backgroundColor: '#ffa94d', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
+        >
+          Close All
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DemoExternalClose() {
+  const [result, setResult] = useState<string>('(no result yet)');
+  const [status, setStatus] = useState<'idle' | 'waiting'>('idle');
+  const [overlayId] = useState('external-close-demo-overlay');
+
+  return (
+    <div>
+      <h2>5. Demo: External Close WITHOUT defaultValue (Promise stays pending)</h2>
+      <p style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
+        Without <code>defaultValue</code>, the Promise never resolves when closed externally.
+      </p>
+      <p>
+        Result: <strong>{result}</strong>
+      </p>
+      <p>
+        Status: <strong style={{ color: status === 'waiting' ? 'orange' : 'green' }}>{status}</strong>
+      </p>
+      <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
+        <button
+          onClick={async () => {
+            setResult('(no result yet)');
+            setStatus('waiting');
+            const value = await overlay.openAsync<boolean>(
+              ({ isOpen, close, unmount }) => {
+                return (
+                  <Modal isOpen={isOpen} onExit={unmount}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 10,
+                      }}
+                    >
+                      <p>Click "Close Externally" - Promise will stay pending!</p>
+                      <button onClick={() => close(true)}>Close Internally (resolves)</button>
+                    </div>
+                  </Modal>
+                );
+              },
+              { overlayId }
+            );
+            setResult(String(value));
+            setStatus('idle');
+          }}
+        >
+          open dialog
+        </button>
+        <button
+          onClick={() => overlay.close(overlayId)}
+          style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
+        >
+          Close Externally (Promise stays pending)
+        </button>
+      </div>
     </div>
   );
 }

--- a/examples/react-19/framer-motion/src/demo.tsx
+++ b/examples/react-19/framer-motion/src/demo.tsx
@@ -13,7 +13,7 @@ export function Demo() {
       <hr style={{ margin: '20px 0' }} />
       <DemoOpenAsyncBasic />
       <hr style={{ margin: '20px 0' }} />
-      <DemoOpenAsyncWithOnDismiss />
+      <DemoOpenAsyncWithDefaultValue />
       <hr style={{ margin: '20px 0' }} />
       <DemoExternalClose />
     </div>
@@ -105,15 +105,17 @@ function DemoOpenAsyncBasic() {
   );
 }
 
-function DemoOpenAsyncWithOnDismiss() {
+function DemoOpenAsyncWithDefaultValue() {
   const [result, setResult] = useState<string>('(no result yet)');
-  const [overlayId] = useState('ondismiss-demo-overlay');
+  const [overlayId] = useState('defaultvalue-demo-overlay');
 
   return (
     <div>
       <h2>4. Demo with overlay.openAsync + defaultValue option</h2>
       <p style={{ fontSize: 14, color: '#666', marginBottom: 10 }}>
         With <code>defaultValue</code>, the Promise resolves even when closed externally.
+        <br />
+        <code>defaultValue: false</code> → external close resolves with <code>false</code>
       </p>
       <p>
         Result: <strong>{result}</strong>
@@ -122,7 +124,7 @@ function DemoOpenAsyncWithOnDismiss() {
         <button
           onClick={async () => {
             setResult('(waiting...)');
-            const value = await overlay.openAsync<boolean | 'dismissed'>(
+            const value = await overlay.openAsync<boolean>(
               ({ isOpen, close, unmount }) => {
                 return (
                   <Modal isOpen={isOpen} onExit={unmount}>
@@ -145,7 +147,7 @@ function DemoOpenAsyncWithOnDismiss() {
                   </Modal>
                 );
               },
-              { overlayId, defaultValue: 'dismissed' }
+              { overlayId, defaultValue: false }
             );
             setResult(String(value));
           }}
@@ -156,13 +158,13 @@ function DemoOpenAsyncWithOnDismiss() {
           onClick={() => overlay.close(overlayId)}
           style={{ backgroundColor: '#ff6b6b', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
         >
-          Close Externally
+          Close Externally (→ false)
         </button>
         <button
           onClick={() => overlay.closeAll()}
           style={{ backgroundColor: '#ffa94d', color: 'white', border: 'none', padding: '8px 16px', borderRadius: 4 }}
         >
-          Close All
+          Close All (→ false)
         </button>
       </div>
     </div>

--- a/packages/src/event.test.tsx
+++ b/packages/src/event.test.tsx
@@ -655,6 +655,108 @@ describe('overlay object', () => {
       // mockFn should still only be called once
       expect(mockFn).toHaveBeenCalledTimes(1);
     });
+
+    it('resolves with onDismiss value when unmounted externally via overlay.unmount()', async () => {
+      const overlayTriggerContent = 'openasync-unmount-trigger';
+      const testOverlayId = 'test-unmount-overlay';
+      const mockFn = vi.fn();
+
+      function Component() {
+        return (
+          <button
+            onClick={async () => {
+              const result = await overlay.openAsync<boolean | undefined>(
+                ({ isOpen }) => isOpen && <div data-testid="overlay-unmount">Dialog</div>,
+                { overlayId: testOverlayId, onDismiss: undefined }
+              );
+              mockFn(result);
+            }}
+          >
+            {overlayTriggerContent}
+          </button>
+        );
+      }
+
+      const { user } = renderWithUser(<Component />);
+      await user.click(await screen.findByRole('button', { name: overlayTriggerContent }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('overlay-unmount')).toBeInTheDocument();
+      });
+
+      act(() => {
+        overlay.unmount(testOverlayId);
+      });
+
+      await waitFor(() => {
+        expect(mockFn).toHaveBeenCalledWith(undefined);
+      });
+    });
+
+    it('resolves with onDismiss value when unmounted via overlay.unmountAll()', async () => {
+      const overlayTriggerContent = 'openasync-unmountall-trigger';
+      const mockFn = vi.fn();
+
+      function Component() {
+        return (
+          <button
+            onClick={async () => {
+              const result = await overlay.openAsync<string | null>(
+                ({ isOpen }) => isOpen && <div data-testid="overlay-unmountall">Dialog</div>,
+                { onDismiss: null }
+              );
+              mockFn(result);
+            }}
+          >
+            {overlayTriggerContent}
+          </button>
+        );
+      }
+
+      const { user } = renderWithUser(<Component />);
+      await user.click(await screen.findByRole('button', { name: overlayTriggerContent }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('overlay-unmountall')).toBeInTheDocument();
+      });
+
+      act(() => {
+        overlay.unmountAll();
+      });
+
+      await waitFor(() => {
+        expect(mockFn).toHaveBeenCalledWith(null);
+      });
+    });
+
+    it('does not subscribe to events when onDismiss is not provided (no memory leak)', async () => {
+      const overlayTriggerContent = 'openasync-no-leak-trigger';
+      const overlayDialogContent = 'openasync-no-leak-dialog';
+      const mockFn = vi.fn();
+
+      function Component() {
+        return (
+          <button
+            onClick={async () => {
+              const result = await overlay.openAsync<boolean>(
+                ({ isOpen, close }) => isOpen && <button onClick={() => close(true)}>{overlayDialogContent}</button>
+              );
+              mockFn(result);
+            }}
+          >
+            {overlayTriggerContent}
+          </button>
+        );
+      }
+
+      const { user } = renderWithUser(<Component />);
+      await user.click(await screen.findByRole('button', { name: overlayTriggerContent }));
+      await user.click(await screen.findByRole('button', { name: overlayDialogContent }));
+
+      await waitFor(() => {
+        expect(mockFn).toHaveBeenCalledWith(true);
+      });
+    });
   });
 
   it('unmount function requires the exact id to be provided', async () => {

--- a/packages/src/event.test.tsx
+++ b/packages/src/event.test.tsx
@@ -457,6 +457,206 @@ describe('overlay object', () => {
     );
   });
 
+  describe('openAsync with onDismiss option', () => {
+    it('resolves with close(value) when called internally (backward compatible)', async () => {
+      const overlayDialogContent = 'openasync-dialog-content';
+      const overlayTriggerContent = 'openasync-trigger-content';
+      const mockFn = vi.fn();
+
+      function Component() {
+        return (
+          <button
+            onClick={async () => {
+              const result = await overlay.openAsync<boolean | undefined>(
+                ({ isOpen, close }) => isOpen && <button onClick={() => close(true)}>{overlayDialogContent}</button>,
+                { onDismiss: undefined }
+              );
+              mockFn(result);
+            }}
+          >
+            {overlayTriggerContent}
+          </button>
+        );
+      }
+
+      const { user } = renderWithUser(<Component />);
+      await user.click(await screen.findByRole('button', { name: overlayTriggerContent }));
+      await user.click(await screen.findByRole('button', { name: overlayDialogContent }));
+
+      await waitFor(() => {
+        expect(mockFn).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it('resolves with onDismiss value when closed externally via overlay.close()', async () => {
+      const overlayDialogContent = 'openasync-external-close-dialog';
+      const overlayTriggerContent = 'openasync-external-close-trigger';
+      const testOverlayId = 'test-external-close-overlay';
+      const mockFn = vi.fn();
+
+      function Component() {
+        return (
+          <button
+            onClick={async () => {
+              const result = await overlay.openAsync<boolean | undefined>(
+                ({ isOpen }) => isOpen && <div data-testid="overlay-content">{overlayDialogContent}</div>,
+                { overlayId: testOverlayId, onDismiss: undefined }
+              );
+              mockFn(result);
+            }}
+          >
+            {overlayTriggerContent}
+          </button>
+        );
+      }
+
+      const { user } = renderWithUser(<Component />);
+      await user.click(await screen.findByRole('button', { name: overlayTriggerContent }));
+
+      // Wait for overlay to be visible
+      await waitFor(() => {
+        expect(screen.getByTestId('overlay-content')).toBeInTheDocument();
+      });
+
+      // Close externally
+      act(() => {
+        overlay.close(testOverlayId);
+      });
+
+      await waitFor(() => {
+        expect(mockFn).toHaveBeenCalledWith(undefined);
+      });
+    });
+
+    it('resolves with onDismiss value when closed via overlay.closeAll()', async () => {
+      const overlayTriggerContent = 'openasync-closeall-trigger';
+      const mockFn = vi.fn();
+
+      function Component() {
+        return (
+          <button
+            onClick={async () => {
+              const result = await overlay.openAsync<string | null>(
+                ({ isOpen }) => isOpen && <div data-testid="overlay-closeall">Dialog</div>,
+                { onDismiss: null }
+              );
+              mockFn(result);
+            }}
+          >
+            {overlayTriggerContent}
+          </button>
+        );
+      }
+
+      const { user } = renderWithUser(<Component />);
+      await user.click(await screen.findByRole('button', { name: overlayTriggerContent }));
+
+      // Wait for overlay to be visible
+      await waitFor(() => {
+        expect(screen.getByTestId('overlay-closeall')).toBeInTheDocument();
+      });
+
+      // Close all overlays
+      act(() => {
+        overlay.closeAll();
+      });
+
+      await waitFor(() => {
+        expect(mockFn).toHaveBeenCalledWith(null);
+      });
+    });
+
+    it('stays pending without onDismiss option when closed externally (backward compatible)', async () => {
+      const overlayTriggerContent = 'openasync-no-ondismiss-trigger';
+      const testOverlayId = 'test-no-ondismiss-overlay';
+      const mockFn = vi.fn();
+
+      function Component() {
+        return (
+          <button
+            onClick={async () => {
+              const result = await overlay.openAsync<boolean>(
+                ({ isOpen }) => isOpen && <div data-testid="overlay-no-ondismiss">Dialog</div>,
+                { overlayId: testOverlayId }
+              );
+              mockFn(result);
+            }}
+          >
+            {overlayTriggerContent}
+          </button>
+        );
+      }
+
+      const { user } = renderWithUser(<Component />);
+      await user.click(await screen.findByRole('button', { name: overlayTriggerContent }));
+
+      // Wait for overlay to be visible
+      await waitFor(() => {
+        expect(screen.getByTestId('overlay-no-ondismiss')).toBeInTheDocument();
+      });
+
+      // Close externally
+      act(() => {
+        overlay.close(testOverlayId);
+      });
+
+      // Wait a bit and verify mockFn was NOT called (Promise stays pending)
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(mockFn).not.toHaveBeenCalled();
+    });
+
+    it('prevents double resolution when close is called after external close', async () => {
+      const overlayTriggerContent = 'openasync-double-resolve-trigger';
+      const testOverlayId = 'test-double-resolve-overlay';
+      const mockFn = vi.fn();
+      let closeRef: ((value: string) => void) | null = null;
+
+      function Component() {
+        return (
+          <button
+            onClick={async () => {
+              const result = await overlay.openAsync<string>(
+                ({ isOpen, close }) => {
+                  closeRef = close;
+                  return isOpen && <div data-testid="overlay-double-resolve">Dialog</div>;
+                },
+                { overlayId: testOverlayId, onDismiss: 'dismissed' }
+              );
+              mockFn(result);
+            }}
+          >
+            {overlayTriggerContent}
+          </button>
+        );
+      }
+
+      const { user } = renderWithUser(<Component />);
+      await user.click(await screen.findByRole('button', { name: overlayTriggerContent }));
+
+      // Wait for overlay to be visible
+      await waitFor(() => {
+        expect(screen.getByTestId('overlay-double-resolve')).toBeInTheDocument();
+      });
+
+      // Close externally first
+      act(() => {
+        overlay.close(testOverlayId);
+      });
+
+      await waitFor(() => {
+        expect(mockFn).toHaveBeenCalledWith('dismissed');
+      });
+
+      // Try to close internally after (should not call mockFn again)
+      act(() => {
+        closeRef?.('internal-value');
+      });
+
+      // mockFn should still only be called once
+      expect(mockFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('unmount function requires the exact id to be provided', async () => {
     const overlayIdMap = {
       first: 'overlay-content-1',

--- a/packages/src/event.test.tsx
+++ b/packages/src/event.test.tsx
@@ -457,7 +457,7 @@ describe('overlay object', () => {
     );
   });
 
-  describe('openAsync with onDismiss option', () => {
+  describe('openAsync with defaultValue option', () => {
     it('resolves with close(value) when called internally (backward compatible)', async () => {
       const overlayDialogContent = 'openasync-dialog-content';
       const overlayTriggerContent = 'openasync-trigger-content';
@@ -469,7 +469,7 @@ describe('overlay object', () => {
             onClick={async () => {
               const result = await overlay.openAsync<boolean | undefined>(
                 ({ isOpen, close }) => isOpen && <button onClick={() => close(true)}>{overlayDialogContent}</button>,
-                { onDismiss: undefined }
+                { defaultValue: undefined }
               );
               mockFn(result);
             }}
@@ -488,7 +488,7 @@ describe('overlay object', () => {
       });
     });
 
-    it('resolves with onDismiss value when closed externally via overlay.close()', async () => {
+    it('resolves with defaultValue value when closed externally via overlay.close()', async () => {
       const overlayDialogContent = 'openasync-external-close-dialog';
       const overlayTriggerContent = 'openasync-external-close-trigger';
       const testOverlayId = 'test-external-close-overlay';
@@ -500,7 +500,7 @@ describe('overlay object', () => {
             onClick={async () => {
               const result = await overlay.openAsync<boolean | undefined>(
                 ({ isOpen }) => isOpen && <div data-testid="overlay-content">{overlayDialogContent}</div>,
-                { overlayId: testOverlayId, onDismiss: undefined }
+                { overlayId: testOverlayId, defaultValue: undefined }
               );
               mockFn(result);
             }}
@@ -528,7 +528,7 @@ describe('overlay object', () => {
       });
     });
 
-    it('resolves with onDismiss value when closed via overlay.closeAll()', async () => {
+    it('resolves with defaultValue value when closed via overlay.closeAll()', async () => {
       const overlayTriggerContent = 'openasync-closeall-trigger';
       const mockFn = vi.fn();
 
@@ -538,7 +538,7 @@ describe('overlay object', () => {
             onClick={async () => {
               const result = await overlay.openAsync<string | null>(
                 ({ isOpen }) => isOpen && <div data-testid="overlay-closeall">Dialog</div>,
-                { onDismiss: null }
+                { defaultValue: null }
               );
               mockFn(result);
             }}
@@ -566,7 +566,7 @@ describe('overlay object', () => {
       });
     });
 
-    it('stays pending without onDismiss option when closed externally (backward compatible)', async () => {
+    it('stays pending without defaultValue option when closed externally (backward compatible)', async () => {
       const overlayTriggerContent = 'openasync-no-ondismiss-trigger';
       const testOverlayId = 'test-no-ondismiss-overlay';
       const mockFn = vi.fn();
@@ -620,7 +620,7 @@ describe('overlay object', () => {
                   closeRef = close;
                   return isOpen && <div data-testid="overlay-double-resolve">Dialog</div>;
                 },
-                { overlayId: testOverlayId, onDismiss: 'dismissed' }
+                { overlayId: testOverlayId, defaultValue: 'dismissed' }
               );
               mockFn(result);
             }}
@@ -656,7 +656,7 @@ describe('overlay object', () => {
       expect(mockFn).toHaveBeenCalledTimes(1);
     });
 
-    it('resolves with onDismiss value when unmounted externally via overlay.unmount()', async () => {
+    it('resolves with defaultValue value when unmounted externally via overlay.unmount()', async () => {
       const overlayTriggerContent = 'openasync-unmount-trigger';
       const testOverlayId = 'test-unmount-overlay';
       const mockFn = vi.fn();
@@ -667,7 +667,7 @@ describe('overlay object', () => {
             onClick={async () => {
               const result = await overlay.openAsync<boolean | undefined>(
                 ({ isOpen }) => isOpen && <div data-testid="overlay-unmount">Dialog</div>,
-                { overlayId: testOverlayId, onDismiss: undefined }
+                { overlayId: testOverlayId, defaultValue: undefined }
               );
               mockFn(result);
             }}
@@ -693,7 +693,7 @@ describe('overlay object', () => {
       });
     });
 
-    it('resolves with onDismiss value when unmounted via overlay.unmountAll()', async () => {
+    it('resolves with defaultValue value when unmounted via overlay.unmountAll()', async () => {
       const overlayTriggerContent = 'openasync-unmountall-trigger';
       const mockFn = vi.fn();
 
@@ -703,7 +703,7 @@ describe('overlay object', () => {
             onClick={async () => {
               const result = await overlay.openAsync<string | null>(
                 ({ isOpen }) => isOpen && <div data-testid="overlay-unmountall">Dialog</div>,
-                { onDismiss: null }
+                { defaultValue: null }
               );
               mockFn(result);
             }}
@@ -729,7 +729,7 @@ describe('overlay object', () => {
       });
     });
 
-    it('does not subscribe to events when onDismiss is not provided (no memory leak)', async () => {
+    it('does not subscribe to events when defaultValue is not provided (no memory leak)', async () => {
       const overlayTriggerContent = 'openasync-no-leak-trigger';
       const overlayDialogContent = 'openasync-no-leak-dialog';
       const mockFn = vi.fn();

--- a/packages/src/event.test.tsx
+++ b/packages/src/event.test.tsx
@@ -467,9 +467,9 @@ describe('overlay object', () => {
         return (
           <button
             onClick={async () => {
-              const result = await overlay.openAsync<boolean | undefined>(
+              const result = await overlay.openAsync<boolean>(
                 ({ isOpen, close }) => isOpen && <button onClick={() => close(true)}>{overlayDialogContent}</button>,
-                { defaultValue: undefined }
+                { defaultValue: false }
               );
               mockFn(result);
             }}
@@ -488,7 +488,7 @@ describe('overlay object', () => {
       });
     });
 
-    it('resolves with defaultValue value when closed externally via overlay.close()', async () => {
+    it('resolves with defaultValue when closed externally via overlay.close()', async () => {
       const overlayDialogContent = 'openasync-external-close-dialog';
       const overlayTriggerContent = 'openasync-external-close-trigger';
       const testOverlayId = 'test-external-close-overlay';
@@ -498,9 +498,9 @@ describe('overlay object', () => {
         return (
           <button
             onClick={async () => {
-              const result = await overlay.openAsync<boolean | undefined>(
+              const result = await overlay.openAsync<boolean>(
                 ({ isOpen }) => isOpen && <div data-testid="overlay-content">{overlayDialogContent}</div>,
-                { overlayId: testOverlayId, defaultValue: undefined }
+                { overlayId: testOverlayId, defaultValue: false }
               );
               mockFn(result);
             }}
@@ -524,11 +524,11 @@ describe('overlay object', () => {
       });
 
       await waitFor(() => {
-        expect(mockFn).toHaveBeenCalledWith(undefined);
+        expect(mockFn).toHaveBeenCalledWith(false);
       });
     });
 
-    it('resolves with defaultValue value when closed via overlay.closeAll()', async () => {
+    it('resolves with defaultValue when closed via overlay.closeAll()', async () => {
       const overlayTriggerContent = 'openasync-closeall-trigger';
       const mockFn = vi.fn();
 
@@ -536,9 +536,9 @@ describe('overlay object', () => {
         return (
           <button
             onClick={async () => {
-              const result = await overlay.openAsync<string | null>(
+              const result = await overlay.openAsync<string>(
                 ({ isOpen }) => isOpen && <div data-testid="overlay-closeall">Dialog</div>,
-                { defaultValue: null }
+                { defaultValue: 'cancelled' }
               );
               mockFn(result);
             }}
@@ -562,7 +562,7 @@ describe('overlay object', () => {
       });
 
       await waitFor(() => {
-        expect(mockFn).toHaveBeenCalledWith(null);
+        expect(mockFn).toHaveBeenCalledWith('cancelled');
       });
     });
 
@@ -656,7 +656,7 @@ describe('overlay object', () => {
       expect(mockFn).toHaveBeenCalledTimes(1);
     });
 
-    it('resolves with defaultValue value when unmounted externally via overlay.unmount()', async () => {
+    it('resolves with defaultValue when unmounted externally via overlay.unmount()', async () => {
       const overlayTriggerContent = 'openasync-unmount-trigger';
       const testOverlayId = 'test-unmount-overlay';
       const mockFn = vi.fn();
@@ -665,9 +665,9 @@ describe('overlay object', () => {
         return (
           <button
             onClick={async () => {
-              const result = await overlay.openAsync<boolean | undefined>(
+              const result = await overlay.openAsync<boolean>(
                 ({ isOpen }) => isOpen && <div data-testid="overlay-unmount">Dialog</div>,
-                { overlayId: testOverlayId, defaultValue: undefined }
+                { overlayId: testOverlayId, defaultValue: false }
               );
               mockFn(result);
             }}
@@ -689,11 +689,11 @@ describe('overlay object', () => {
       });
 
       await waitFor(() => {
-        expect(mockFn).toHaveBeenCalledWith(undefined);
+        expect(mockFn).toHaveBeenCalledWith(false);
       });
     });
 
-    it('resolves with defaultValue value when unmounted via overlay.unmountAll()', async () => {
+    it('resolves with defaultValue when unmounted via overlay.unmountAll()', async () => {
       const overlayTriggerContent = 'openasync-unmountall-trigger';
       const mockFn = vi.fn();
 
@@ -701,9 +701,9 @@ describe('overlay object', () => {
         return (
           <button
             onClick={async () => {
-              const result = await overlay.openAsync<string | null>(
+              const result = await overlay.openAsync<string>(
                 ({ isOpen }) => isOpen && <div data-testid="overlay-unmountall">Dialog</div>,
-                { defaultValue: null }
+                { defaultValue: 'unmounted' }
               );
               mockFn(result);
             }}
@@ -725,7 +725,7 @@ describe('overlay object', () => {
       });
 
       await waitFor(() => {
-        expect(mockFn).toHaveBeenCalledWith(null);
+        expect(mockFn).toHaveBeenCalledWith('unmounted');
       });
     });
 

--- a/packages/src/event.ts
+++ b/packages/src/event.ts
@@ -39,28 +39,51 @@ export function createOverlay(overlayId: string) {
   const openAsync = async <T>(controller: OverlayAsyncControllerComponent<T>, options?: OpenAsyncOverlayOptions<T>) => {
     return new Promise<T>((_resolve, _reject) => {
       let resolved = false;
+      const hasOnDismiss = options !== undefined && 'onDismiss' in options;
+
+      const cleanup = () => {
+        unsubscribeClose();
+        unsubscribeCloseAll();
+        unsubscribeUnmount();
+        unsubscribeUnmountAll();
+      };
 
       const resolve = (value: T) => {
         if (resolved) return;
         resolved = true;
-        unsubscribeClose();
-        unsubscribeCloseAll();
+        cleanup();
         _resolve(value);
       };
 
       const currentOverlayId = options?.overlayId ?? randomId();
 
-      const unsubscribeClose = subscribeEvent('close', (closedOverlayId: string) => {
-        if (closedOverlayId === currentOverlayId && 'onDismiss' in (options ?? {})) {
-          resolve(options!.onDismiss as T);
-        }
-      });
+      const unsubscribeClose = hasOnDismiss
+        ? subscribeEvent('close', (closedOverlayId: string) => {
+            if (closedOverlayId === currentOverlayId) {
+              resolve(options!.onDismiss as T);
+            }
+          })
+        : () => {};
 
-      const unsubscribeCloseAll = subscribeEvent('closeAll', () => {
-        if ('onDismiss' in (options ?? {})) {
-          resolve(options!.onDismiss as T);
-        }
-      });
+      const unsubscribeCloseAll = hasOnDismiss
+        ? subscribeEvent('closeAll', () => {
+            resolve(options!.onDismiss as T);
+          })
+        : () => {};
+
+      const unsubscribeUnmount = hasOnDismiss
+        ? subscribeEvent('unmount', (unmountedOverlayId: string) => {
+            if (unmountedOverlayId === currentOverlayId) {
+              resolve(options!.onDismiss as T);
+            }
+          })
+        : () => {};
+
+      const unsubscribeUnmountAll = hasOnDismiss
+        ? subscribeEvent('unmountAll', () => {
+            resolve(options!.onDismiss as T);
+          })
+        : () => {};
 
       open(
         (overlayProps, ...deprecatedLegacyContext) => {
@@ -72,8 +95,7 @@ export function createOverlay(overlayId: string) {
           const reject = (reason?: unknown) => {
             if (resolved) return;
             resolved = true;
-            unsubscribeClose();
-            unsubscribeCloseAll();
+            cleanup();
             _reject(reason);
             overlayProps.close();
           };

--- a/packages/src/event.ts
+++ b/packages/src/event.ts
@@ -18,8 +18,14 @@ type OpenOverlayOptions = {
   overlayId?: string;
 };
 
+type OpenAsyncOverlayOptions<T> = OpenOverlayOptions & {
+  onDismiss?: T;
+};
+
 export function createOverlay(overlayId: string) {
-  const [useOverlayEvent, createEvent] = createUseExternalEvents<OverlayEvent>(`${overlayId}/overlay-kit`);
+  const [useOverlayEvent, createEvent, subscribeEvent] = createUseExternalEvents<OverlayEvent>(
+    `${overlayId}/overlay-kit`
+  );
 
   const open = (controller: OverlayControllerComponent, options?: OpenOverlayOptions) => {
     const overlayId = options?.overlayId ?? randomId();
@@ -30,31 +36,53 @@ export function createOverlay(overlayId: string) {
     return overlayId;
   };
 
-  const openAsync = async <T>(controller: OverlayAsyncControllerComponent<T>, options?: OpenOverlayOptions) => {
+  const openAsync = async <T>(controller: OverlayAsyncControllerComponent<T>, options?: OpenAsyncOverlayOptions<T>) => {
     return new Promise<T>((_resolve, _reject) => {
-      open((overlayProps, ...deprecatedLegacyContext) => {
-        /**
-         * @description close the overlay with resolve
-         */
-        const close = (param: T) => {
-          _resolve(param);
-          overlayProps.close();
-        };
+      let resolved = false;
 
-        /**
-         * @description close the overlay with reject
-         */
-        const reject = (reason?: unknown) => {
-          _reject(reason);
-          overlayProps.close();
-        };
+      const resolve = (value: T) => {
+        if (resolved) return;
+        resolved = true;
+        unsubscribeClose();
+        unsubscribeCloseAll();
+        _resolve(value);
+      };
 
-        /**
-         * @description Passing overridden methods
-         */
-        const props: OverlayAsyncControllerProps<T> = { ...overlayProps, close, reject };
-        return controller(props, ...deprecatedLegacyContext);
-      }, options);
+      const currentOverlayId = options?.overlayId ?? randomId();
+
+      const unsubscribeClose = subscribeEvent('close', (closedOverlayId: string) => {
+        if (closedOverlayId === currentOverlayId && 'onDismiss' in (options ?? {})) {
+          resolve(options!.onDismiss as T);
+        }
+      });
+
+      const unsubscribeCloseAll = subscribeEvent('closeAll', () => {
+        if ('onDismiss' in (options ?? {})) {
+          resolve(options!.onDismiss as T);
+        }
+      });
+
+      open(
+        (overlayProps, ...deprecatedLegacyContext) => {
+          const close = (param: T) => {
+            resolve(param);
+            overlayProps.close();
+          };
+
+          const reject = (reason?: unknown) => {
+            if (resolved) return;
+            resolved = true;
+            unsubscribeClose();
+            unsubscribeCloseAll();
+            _reject(reason);
+            overlayProps.close();
+          };
+
+          const props: OverlayAsyncControllerProps<T> = { ...overlayProps, close, reject };
+          return controller(props, ...deprecatedLegacyContext);
+        },
+        { overlayId: currentOverlayId }
+      );
     });
   };
 

--- a/packages/src/event.ts
+++ b/packages/src/event.ts
@@ -36,11 +36,43 @@ export function createOverlay(overlayId: string) {
     return overlayId;
   };
 
+  /**
+   * Opens an overlay and returns a Promise that resolves when the overlay is closed.
+   *
+   * ## External Event Subscription Pattern
+   *
+   * When `defaultValue` is provided, this function subscribes to external close/unmount events
+   * using `subscribeEvent` (outside React's lifecycle). This enables the Promise to resolve
+   * even when closed externally via `overlay.close(id)` or `overlay.closeAll()`.
+   *
+   * ### Why subscribe outside React hooks?
+   * - Promise executor runs outside React component lifecycle
+   * - Cannot use `useEffect` for cleanup - must manage manually
+   * - `subscribeEvent` returns unsubscribe function for manual cleanup
+   *
+   * ### Memory safety guarantees:
+   * 1. `resolved` flag prevents double-resolution
+   * 2. `cleanup()` unsubscribes ALL event listeners on resolution
+   * 3. Conditional subscription - no listeners if `defaultValue` not provided
+   *
+   * @param controller - Render function receiving overlay props (isOpen, close, reject)
+   * @param options - Optional config: `overlayId` and `defaultValue`
+   * @param options.defaultValue - Value to resolve with when closed externally.
+   *                               If not provided, Promise stays pending on external close (backward compatible)
+   */
   const openAsync = async <T>(controller: OverlayAsyncControllerComponent<T>, options?: OpenAsyncOverlayOptions<T>) => {
     return new Promise<T>((_resolve, _reject) => {
+      /**
+       * Prevents double-resolution of the Promise.
+       * Once resolved/rejected, subsequent calls to resolve() are no-ops.
+       */
       let resolved = false;
       const hasDefaultValue = options !== undefined && 'defaultValue' in options;
 
+      /**
+       * Unsubscribes all external event listeners.
+       * MUST be called when Promise settles to prevent memory leaks.
+       */
       const cleanup = () => {
         unsubscribeClose();
         unsubscribeCloseAll();
@@ -48,6 +80,10 @@ export function createOverlay(overlayId: string) {
         unsubscribeUnmountAll();
       };
 
+      /**
+       * Resolves the Promise with given value.
+       * Idempotent - only the first call takes effect.
+       */
       const resolve = (value: T) => {
         if (resolved) return;
         resolved = true;
@@ -57,6 +93,14 @@ export function createOverlay(overlayId: string) {
 
       const currentOverlayId = options?.overlayId ?? randomId();
 
+      /*
+       * External Event Subscriptions (only when defaultValue is provided)
+       *
+       * These subscriptions allow the Promise to resolve when the overlay is closed
+       * from outside (e.g., overlay.close(id), overlay.closeAll()).
+       *
+       * Without defaultValue: subscriptions are no-op functions (backward compatible)
+       */
       const unsubscribeClose = hasDefaultValue
         ? subscribeEvent('close', (closedOverlayId: string) => {
             if (closedOverlayId === currentOverlayId) {

--- a/packages/src/event.ts
+++ b/packages/src/event.ts
@@ -19,7 +19,7 @@ type OpenOverlayOptions = {
 };
 
 type OpenAsyncOverlayOptions<T> = OpenOverlayOptions & {
-  onDismiss?: T;
+  defaultValue?: T;
 };
 
 export function createOverlay(overlayId: string) {
@@ -39,7 +39,7 @@ export function createOverlay(overlayId: string) {
   const openAsync = async <T>(controller: OverlayAsyncControllerComponent<T>, options?: OpenAsyncOverlayOptions<T>) => {
     return new Promise<T>((_resolve, _reject) => {
       let resolved = false;
-      const hasOnDismiss = options !== undefined && 'onDismiss' in options;
+      const hasDefaultValue = options !== undefined && 'defaultValue' in options;
 
       const cleanup = () => {
         unsubscribeClose();
@@ -57,31 +57,31 @@ export function createOverlay(overlayId: string) {
 
       const currentOverlayId = options?.overlayId ?? randomId();
 
-      const unsubscribeClose = hasOnDismiss
+      const unsubscribeClose = hasDefaultValue
         ? subscribeEvent('close', (closedOverlayId: string) => {
             if (closedOverlayId === currentOverlayId) {
-              resolve(options!.onDismiss as T);
+              resolve(options!.defaultValue as T);
             }
           })
         : () => {};
 
-      const unsubscribeCloseAll = hasOnDismiss
+      const unsubscribeCloseAll = hasDefaultValue
         ? subscribeEvent('closeAll', () => {
-            resolve(options!.onDismiss as T);
+            resolve(options!.defaultValue as T);
           })
         : () => {};
 
-      const unsubscribeUnmount = hasOnDismiss
+      const unsubscribeUnmount = hasDefaultValue
         ? subscribeEvent('unmount', (unmountedOverlayId: string) => {
             if (unmountedOverlayId === currentOverlayId) {
-              resolve(options!.onDismiss as T);
+              resolve(options!.defaultValue as T);
             }
           })
         : () => {};
 
-      const unsubscribeUnmountAll = hasOnDismiss
+      const unsubscribeUnmountAll = hasDefaultValue
         ? subscribeEvent('unmountAll', () => {
-            resolve(options!.onDismiss as T);
+            resolve(options!.defaultValue as T);
           })
         : () => {};
 

--- a/packages/src/utils/create-use-external-events.ts
+++ b/packages/src/utils/create-use-external-events.ts
@@ -54,5 +54,19 @@ export function createUseExternalEvents<EventHandlers extends Record<string, (pa
     return (...payload: Parameters<EventHandlers[EventKey]>) => dispatchEvent(`${prefix}:${String(event)}`, payload[0]);
   }
 
-  return [useExternalEvents, createEvent] as const;
+  function subscribeEvent<EventKey extends keyof EventHandlers>(
+    event: EventKey,
+    handler: EventHandlers[EventKey]
+  ): () => void {
+    const eventKey = `${prefix}:${String(event)}`;
+    const wrappedHandler = (payload: Parameters<EventHandlers[EventKey]>[0]) => {
+      handler(payload);
+    };
+    emitter.on(eventKey, wrappedHandler);
+    return () => {
+      emitter.off(eventKey, wrappedHandler);
+    };
+  }
+
+  return [useExternalEvents, createEvent, subscribeEvent] as const;
 }

--- a/packages/src/utils/create-use-external-events.ts
+++ b/packages/src/utils/create-use-external-events.ts
@@ -19,7 +19,36 @@ function dispatchEvent<Detail>(type: string, detail?: Detail) {
   emitter.emit(type, detail);
 }
 
-// When creating an event, params can be of any type, so specify the type as any.
+/**
+ * Creates a set of utilities for managing external events in overlay-kit.
+ *
+ * This factory function returns three utilities:
+ * 1. `useExternalEvents` - React Hook for subscribing to events within components
+ * 2. `createEvent` - Factory for creating event dispatchers
+ * 3. `subscribeEvent` - Function for subscribing to events outside of React components
+ *
+ * @remarks
+ * EventHandlers uses `any` for params because event payloads can be of any type.
+ *
+ * @param prefix - Namespace prefix to avoid event name collisions (e.g., 'overlay-kit')
+ *
+ * @example
+ * ```typescript
+ * const [useOverlayEvent, createEvent, subscribeEvent] = createUseExternalEvents<OverlayEvent>('my-app/overlay');
+ *
+ * // In React component
+ * useOverlayEvent({ open: (payload) => console.log('opened', payload) });
+ *
+ * // Dispatching events
+ * const dispatchOpen = createEvent('open');
+ * dispatchOpen({ overlayId: '123' });
+ *
+ * // Outside React (e.g., in Promise)
+ * const unsubscribe = subscribeEvent('close', (id) => console.log('closed', id));
+ * // IMPORTANT: Always call unsubscribe when done
+ * unsubscribe();
+ * ```
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createUseExternalEvents<EventHandlers extends Record<string, (params: any) => void>>(prefix: string) {
   function useExternalEvents(events: EventHandlers) {
@@ -54,6 +83,33 @@ export function createUseExternalEvents<EventHandlers extends Record<string, (pa
     return (...payload: Parameters<EventHandlers[EventKey]>) => dispatchEvent(`${prefix}:${String(event)}`, payload[0]);
   }
 
+  /**
+   * Subscribes to an event outside of React's lifecycle (e.g., inside a Promise).
+   *
+   * Unlike `useExternalEvents` which automatically cleans up on unmount,
+   * this function requires MANUAL cleanup by calling the returned unsubscribe function.
+   *
+   * @warning Memory Leak Risk - Always call the returned unsubscribe function when done.
+   *
+   * @param event - Event type to subscribe to
+   * @param handler - Callback function to handle the event
+   * @returns Unsubscribe function that MUST be called to prevent memory leaks
+   *
+   * @example
+   * ```typescript
+   * // Inside openAsync Promise
+   * const unsubscribe = subscribeEvent('close', (overlayId) => {
+   *   if (overlayId === currentId) {
+   *     resolve(defaultValue);
+   *   }
+   * });
+   *
+   * // Cleanup when Promise resolves
+   * const cleanup = () => {
+   *   unsubscribe();
+   * };
+   * ```
+   */
   function subscribeEvent<EventKey extends keyof EventHandlers>(
     event: EventKey,
     handler: EventHandlers[EventKey]


### PR DESCRIPTION
## Summary

Fixes `overlay.openAsync` Promise not resolving when the overlay is closed externally (via `overlay.close(id)` rather than the internal `close(value)` callback).

Adds a `defaultValue` option to specify what value to resolve in such cases.

Closes #169


https://github.com/user-attachments/assets/1a57ca1a-80ff-4b9c-80d3-6d5af465c2f9



---

## 🔴 PROBLEM

### Core Issue

| Item | Detail |
|------|--------|
| **Issue** | `overlay.openAsync()` Promise **never resolves** when closed externally |
| **Related Issue** | #169 - Already reported |

### Requirements & Constraints

| Requirement | Source | Description |
|-------------|--------|-------------|
| **No Breaking Changes** | [#169 Comment](https://github.com/toss/overlay-kit/issues/169) | Maintainer emphasized that any fix must not break existing behavior |
| **Backward Compatible** | Community feedback | Existing `openAsync` calls without options must continue to work unchanged |
| **Opt-in Behavior** | Design decision | New functionality should only activate when explicitly requested |

> **Key Constraint from Issue #169:**  
> The maintainer commented that the solution must be implemented **without breaking changes**.  
> This constraint led to the design choice of using an **optional `defaultValue` parameter** rather than changing the default behavior of `openAsync`.

### Problem Scenario

```typescript
const result = await overlay.openAsync<boolean>(({ isOpen, close }) => (
  <Dialog open={isOpen} onConfirm={() => close(true)} />
));
// ❌ This line NEVER executes when overlay.close(id) is called
console.log(result);
```

| Close Method | Promise State |
|--------------|---------------|
| Internal `close(value)` call | ✅ Resolved |
| External `overlay.close(id)` call | ❌ **Pending forever** |
| External `overlay.closeAll()` call | ❌ **Pending forever** |
| External `overlay.unmount(id)` call | ❌ **Pending forever** |

### Real-World Scenarios Where This Occurs

1. **Browser back button** - Global handler calls `overlay.close()`
2. **ESC key handler** - External listener closes overlay programmatically
3. **Auto-close timer** - `setTimeout(() => overlay.close(id), 5000)`
4. **Route change** - Navigation cleanup closes all overlays
5. **Parent component unmount** - Cleanup effect calls `overlay.close()`

### Technical Root Cause

```typescript
// event.ts - The problematic code
const openAsync = async <T>(controller, options) => {
  return new Promise<T>((_resolve) => {
    open((overlayProps) => {
      // ⚠️ Only THIS close function resolves the Promise
      const close = (param: T) => {
        _resolve(param);      // ← Resolution happens ONLY here
        overlayProps.close();
      };
      return controller({ ...overlayProps, close });
    }, options);
  });
};
```

**Call Flow Comparison:**

```
[Internal close] close(true) → _resolve(true) → ✅ Promise resolved
[External close] overlay.close(id) → reducer CLOSE → isOpen=false → ❌ _resolve never called
```

### Downstream Problems

| Problem | Description |
|---------|-------------|
| **Memory Leak** | Unresolved Promises and their closures remain in memory |
| **Deadlock** | `await` blocks indefinitely, subsequent code never runs |
| **Poor UX** | Application appears frozen after external close |

---

## 🟢 ACTION

### Design Rationale: Why `defaultValue` Option?

The solution uses an **optional `defaultValue` parameter** to satisfy the **no breaking changes** requirement from issue #169:

| Approach Considered | Breaking Change? | Why Not Chosen |
|---------------------|------------------|----------------|
| Always resolve with `undefined` on external close | ✅ Yes | Changes return type, breaks existing code expecting specific values |
| Add new method `openAsyncSafe()` | ❌ No | API fragmentation, confusing which to use |
| **Add optional `defaultValue` parameter** | ❌ No | ✅ **Chosen** - Opt-in, backward compatible |

**Why this works:**
- Without `defaultValue`: Behavior unchanged (Promise stays pending on external close)
- With `defaultValue`: Promise resolves with specified value on external close
- Existing code requires **zero modifications**

### Design Decisions

| Item | Initial Plan | Final Implementation | Reason for Change |
|------|--------------|---------------------|-------------------|
| **Option Name** | `onDismiss` | `defaultValue` | Clearer semantic meaning |
| **Events Monitored** | `close`, `closeAll` | + `unmount`, `unmountAll` | Cover all external close cases |
| **Memory Management** | Not considered | `cleanup()` function added | Prevent memory leaks |
| **API Approach** | New method (`openAsyncSafe`) | Add option to existing method | Maintain backward compatibility, per #169 requirement |

---

## ⚠️ Technical Considerations: Event Subscription Outside React Hooks

### Background: Hook vs External Subscription

Previously, overlay-kit only subscribed to events **inside React hooks** via `useExternalEvents`. This change introduces `subscribeEvent` to subscribe **outside React's lifecycle** (inside a Promise executor).

| Aspect | Hook Subscription (`useExternalEvents`) | External Subscription (`subscribeEvent`) |
|--------|----------------------------------------|------------------------------------------|
| **Context** | Inside React component | Outside React (Promise, callback, etc.) |
| **Lifecycle** | Tied to component mount/unmount | Manual management required |
| **Cleanup** | Automatic via `useEffect` return | **Manual** - must call unsubscribe |
| **Memory Safety** | React handles cleanup | Developer responsibility |
| **Use Case** | OverlayProvider listening to events | openAsync Promise waiting for close |

### Potential Risks Identified

#### 1. Memory Leak Risk

**Problem:** Without React's automatic cleanup, event listeners could remain in memory indefinitely.

```typescript
// ❌ RISK: If Promise never settles, subscription stays forever
const unsubscribe = subscribeEvent('close', handler);
// If we never call unsubscribe(), handler remains in emitter's Map
```

**Mitigation:**

```typescript
// ✅ SOLUTION: cleanup() called on EVERY resolution path
const cleanup = () => {
  unsubscribeClose();
  unsubscribeCloseAll();
  unsubscribeUnmount();
  unsubscribeUnmountAll();
};

const resolve = (value: T) => {
  if (resolved) return;
  resolved = true;
  cleanup();  // Always cleanup before resolving
  _resolve(value);
};

const reject = (reason?: unknown) => {
  if (resolved) return;
  resolved = true;
  cleanup();  // Always cleanup before rejecting
  _reject(reason);
};
```

#### 2. Double Resolution Risk

**Problem:** Both internal `close(value)` and external `overlay.close(id)` could try to resolve the same Promise.

```typescript
// ❌ RISK: Race condition
// 1. User clicks confirm → close(true) → _resolve(true)
// 2. Simultaneously, external close event arrives → _resolve(defaultValue)
// Promise resolved twice! (Actually throws in strict mode)
```

**Mitigation:**

```typescript
// ✅ SOLUTION: resolved flag ensures single resolution
let resolved = false;

const resolve = (value: T) => {
  if (resolved) return;  // Guard: ignore if already resolved
  resolved = true;
  cleanup();
  _resolve(value);
};
```

#### 3. Handler Reference Management

**Problem:** `emitter.off()` requires the exact same function reference as `emitter.on()`.

```typescript
// ❌ RISK: Wrong reference = handler never removed
emitter.on('close', (id) => handler(id));
emitter.off('close', (id) => handler(id));  // Different function! Not removed.
```

**Mitigation:**

```typescript
// ✅ SOLUTION: subscribeEvent captures reference in closure
function subscribeEvent(event, handler) {
  const eventKey = `${prefix}:${String(event)}`;
  const wrappedHandler = (payload) => handler(payload);  // Captured reference
  emitter.on(eventKey, wrappedHandler);
  return () => {
    emitter.off(eventKey, wrappedHandler);  // Same reference
  };
}
```

#### 4. Subscription Timing (Race Condition)

**Problem:** Event might fire before subscription is established.

```typescript
// ❌ RISK: Theoretical race condition
subscribeEvent('close', handler);  // Step 1: Subscribe
open(controller);                   // Step 2: Open overlay
// What if close event fires between Step 1 and Step 2?
```

**Mitigation:**

- JavaScript is single-threaded; synchronous code runs to completion
- Subscriptions are set up **before** `open()` is called
- No actual race condition possible in this synchronous flow

```typescript
// ✅ SOLUTION: Subscription order guarantees safety
const unsubscribeClose = hasDefaultValue
  ? subscribeEvent('close', handler)  // 1. Subscribe first
  : () => {};

open(controller, { overlayId });       // 2. Then open
// Close event can only fire AFTER open() returns
```

#### 5. Global Singleton Emitter

**Problem:** All overlay instances share one emitter. Could cause cross-contamination.

```typescript
// ❌ RISK: Events from different overlays mixing
const emitter = createEmitter();  // Module-level singleton
```

**Mitigation:**

- Event keys are **namespaced** with prefix: `${prefix}:${event}`
- Each overlay context has unique prefix
- Subscription handlers check `overlayId` before acting

```typescript
// ✅ SOLUTION: ID-based filtering
subscribeEvent('close', (closedOverlayId: string) => {
  if (closedOverlayId === currentOverlayId) {  // Only react to OUR overlay
    resolve(options.defaultValue as T);
  }
});
```

#### 6. Conditional Subscription (Unnecessary Listeners)

**Problem:** Subscribing when not needed wastes resources.

```typescript
// ❌ RISK: Subscribing even when defaultValue not provided
const unsubscribe = subscribeEvent('close', handler);
// If no defaultValue, why subscribe at all?
```

**Mitigation:**

```typescript
// ✅ SOLUTION: Only subscribe when defaultValue exists
const hasDefaultValue = options !== undefined && 'defaultValue' in options;

const unsubscribeClose = hasDefaultValue
  ? subscribeEvent('close', handler)
  : () => {};  // No-op if not needed
```

### Summary: Risk Mitigation Matrix

| Risk | Severity | Mitigation | Status |
|------|----------|------------|--------|
| Memory Leak | 🔴 High | `cleanup()` on all exit paths | ✅ Resolved |
| Double Resolution | 🔴 High | `resolved` flag guard | ✅ Resolved |
| Handler Reference Mismatch | 🟡 Medium | Closure captures reference | ✅ Resolved |
| Race Condition (timing) | 🟢 Low | Synchronous subscription before open | ✅ N/A |
| Global Emitter Contamination | 🟡 Medium | Namespace prefix + ID filtering | ✅ Resolved |
| Unnecessary Subscriptions | 🟢 Low | Conditional subscription | ✅ Resolved |

---

### Core Implementation

**1. New Option Type**

```typescript
type OpenAsyncOverlayOptions<T> = OpenOverlayOptions & {
  defaultValue?: T;  // 🆕 Value to resolve when closed externally
};
```

**2. External Event Subscription (using subscribeEvent)**

```typescript
// Subscribe to events outside React hooks
const unsubscribeClose = hasDefaultValue
  ? subscribeEvent('close', (closedOverlayId) => {
      if (closedOverlayId === currentOverlayId) {
        resolve(options.defaultValue as T);
      }
    })
  : () => {};
```

**3. Memory Leak Prevention**

```typescript
const cleanup = () => {
  unsubscribeClose();
  unsubscribeCloseAll();
  unsubscribeUnmount();
  unsubscribeUnmountAll();
};

const resolve = (value: T) => {
  if (resolved) return;  // Prevent double resolution
  resolved = true;
  cleanup();             // 🆕 Unsubscribe all listeners
  _resolve(value);
};
```

**4. Conditional Subscription (Backward Compatibility)**

```typescript
const hasDefaultValue = options !== undefined && 'defaultValue' in options;

// No subscription without defaultValue → maintains existing behavior (pending)
const unsubscribeClose = hasDefaultValue ? subscribeEvent(...) : () => {};
```

### Additional Issues Resolved

| Pre-existing Issue | Solution |
|-------------------|----------|
| **#169 - Promise pending forever** | `defaultValue` option resolves on external close |
| **Memory leak (unreported)** | `cleanup()` function unsubscribes all listeners |
| **Unmount events not handled (unreported)** | Added `unmount`, `unmountAll` event subscriptions |
| **Double resolution possible (unreported)** | `resolved` flag prevents it |

---

## 🔵 RESULT

### Usage Example (Before vs After)

**Before: The Problem**

```typescript
const result = await overlay.openAsync<boolean>(
  ({ isOpen, close }) => <Dialog onConfirm={() => close(true)} />
);
// When overlay.close(id) is called → ❌ Pending forever
```

**After: The Solution**

```typescript
const result = await overlay.openAsync<boolean>(
  ({ isOpen, close }) => <Dialog onConfirm={() => close(true)} />,
  { defaultValue: false }  // 🆕 Resolves with false on external close
);

if (result === true) {
  console.log('User clicked confirm');
} else {
  console.log('Closed externally (ESC, back button, timeout, etc.)');
}
```

### Test Coverage

| Test Case | Status |
|-----------|--------|
| Internal `close(value)` resolves with that value | ✅ |
| External `overlay.close()` resolves with `defaultValue` | ✅ |
| `overlay.closeAll()` resolves with `defaultValue` | ✅ |
| `overlay.unmount()` resolves with `defaultValue` | ✅ |
| `overlay.unmountAll()` resolves with `defaultValue` | ✅ |
| Without `defaultValue`, maintains existing behavior (pending) | ✅ |
| Prevents double resolution | ✅ |
| No memory leak due to subscription cleanup | ✅ |


### Key Benefits

| Benefit | Description |
|---------|-------------|
| **Backward Compatible** | Existing code works without any changes when `defaultValue` is not provided |
| **Opt-in Behavior** | Only add the option when needed |
| **Complete Coverage** | Handles `close`, `closeAll`, `unmount`, `unmountAll` |
| **Memory Safe** | Automatic subscription cleanup prevents leaks |
| **Type Safe** | Generic `<T>` applies to `defaultValue` as well |

---

## 📐 Architecture Change (AS-IS / TO-BE)

### Event Subscription Layer

**AS-IS: Only React Hook subscription**

```mermaid
flowchart TD
    subgraph LAYER["create-use-external-events.ts"]
        UEE["useExternalEvents()<br/>React Hook"]
        CE["createEvent()<br/>Event Dispatcher"]
    end
    
    subgraph EMITTER["Emitter"]
        ON["emitter.on()"]
        EMIT["emitter.emit()"]
    end
    
    UEE -->|"useLayoutEffect"| ON
    CE -->|"dispatch"| EMIT
```

**TO-BE: Added external subscription function**

```mermaid
flowchart TD
    subgraph LAYER["create-use-external-events.ts"]
        UEE["useExternalEvents()<br/>React Hook"]
        CE["createEvent()<br/>Event Dispatcher"]
        SE["subscribeEvent() 🆕<br/>External Subscription"]
    end
    
    subgraph EMITTER["Emitter"]
        ON["emitter.on()"]
        OFF["emitter.off()"]
        EMIT["emitter.emit()"]
    end
    
    UEE -->|"useLayoutEffect"| ON
    UEE -->|"cleanup"| OFF
    CE -->|"dispatch"| EMIT
    SE -->|"subscribe"| ON
    SE -->|"returns unsubscribe"| OFF
```

---

### Promise Resolution Flow

**AS-IS: External close → Promise pending forever**

```mermaid
flowchart TD
    subgraph INTERNAL["Internal Close ✅"]
        I1["User clicks button"] --> I2["close(value)"]
        I2 --> I3["_resolve(value)"]
        I3 --> I4["Promise Resolved"]
    end
    
    subgraph EXTERNAL["External Close ❌"]
        E1["overlay.close(id)"] --> E2["emit 'close' event"]
        E2 --> E3["useOverlayEvent receives"]
        E3 --> E4["UI closes (isOpen=false)"]
        E4 --> E5["❌ _resolve never called"]
        E5 --> E6["Promise Pending Forever"]
    end
    
    style E5 fill:#f66,stroke:#333
    style E6 fill:#f66,stroke:#333
```

**TO-BE: External close → Promise resolves with defaultValue**

```mermaid
flowchart TD
    subgraph INTERNAL["Internal Close ✅"]
        I1["User clicks button"] --> I2["close(value)"]
        I2 --> I3["cleanup()"]
        I3 --> I4["_resolve(value)"]
        I4 --> I5["Promise Resolved"]
    end
    
    subgraph EXTERNAL["External Close ✅ 🆕"]
        E1["overlay.close(id)"] --> E2["emit 'close' event"]
        E2 --> E3["subscribeEvent handler triggered"]
        E3 --> E4{"resolved?"}
        E4 -->|"No"| E5["cleanup()"]
        E5 --> E6["_resolve(defaultValue)"]
        E6 --> E7["Promise Resolved with defaultValue"]
        E4 -->|"Yes"| E8["Skip (already resolved)"]
    end
    
    style E7 fill:#6f6,stroke:#333
```

---

### Multiple Subscribers Pattern

**AS-IS: Single subscriber (React Hook only)**

```mermaid
flowchart LR
    E["emit('close', overlayId)"]
    E --> S1["OverlayProvider<br/>(useOverlayEvent)"]
    S1 --> R1["UI Update"]
    
    X["openAsync Promise"] -.->|"❌ No connection"| E
```

**TO-BE: Multiple subscribers (Hook + External)**

```mermaid
flowchart LR
    E["emit('close', overlayId)"]
    
    E --> S1["OverlayProvider<br/>(useOverlayEvent)"]
    E --> S2["openAsync 🆕<br/>(subscribeEvent)"]
    
    S1 --> R1["UI Update"]
    S2 --> R2["Promise Resolve"]
    
    style S2 fill:#9f9,stroke:#333
    style R2 fill:#9f9,stroke:#333
```

---

### Data Flow Overview

**AS-IS**

```mermaid
flowchart TD
    USER["User Code<br/>overlay.openAsync()"]
    
    subgraph EVENT["Event Layer"]
        CREATE["createEvent()"]
        EMIT["emit()"]
    end
    
    subgraph REACT["React Layer"]
        HOOK["useOverlayEvent"]
        REDUCER["useReducer"]
    end
    
    UI["Overlay UI"]
    
    USER --> CREATE --> EMIT
    EMIT --> HOOK --> REDUCER --> UI
    
    USER -.->|"❌ No feedback<br/>on external close"| USER
```

**TO-BE**

```mermaid
flowchart TD
    USER["User Code<br/>overlay.openAsync()"]
    
    subgraph EVENT["Event Layer"]
        CREATE["createEvent()"]
        EMIT["emit()"]
        SUB["subscribeEvent() 🆕"]
    end
    
    subgraph REACT["React Layer"]
        HOOK["useOverlayEvent"]
        REDUCER["useReducer"]
    end
    
    UI["Overlay UI"]
    
    USER --> CREATE --> EMIT
    EMIT --> HOOK --> REDUCER --> UI
    EMIT --> SUB
    SUB -->|"✅ Resolve with<br/>defaultValue"| USER
    
    style SUB fill:#9f9,stroke:#333
```

---

## Changes

- `packages/src/event.ts` - Add `defaultValue` option to `openAsync`
- `packages/src/utils/create-use-external-events.ts` - Add `subscribeEvent` function
- `packages/src/event.test.tsx` - Add comprehensive test cases
- `examples/*/demo.tsx` - Sync demo across React versions

## Breaking Changes

None. This is a backward-compatible change.