### PR TITLE
fix: cancel requestAnimationFrame on unmount in ContentOverlayController

### DIFF
--- a/packages/src/context/provider/content-overlay-controller.tsx
+++ b/packages/src/context/provider/content-overlay-controller.tsx
@@ -26,9 +26,11 @@ type ContentOverlayControllerProps = {
 export const ContentOverlayController = memo(
   ({ isOpen, overlayId, overlayDispatch, controller: Controller }: ContentOverlayControllerProps) => {
     useEffect(() => {
-      requestAnimationFrame(() => {
+      const frameId = requestAnimationFrame(() => {
         overlayDispatch({ type: 'OPEN', overlayId });
       });
+
+      return () => cancelAnimationFrame(frameId);
     }, [overlayDispatch, overlayId]);
 
     return (


### PR DESCRIPTION
## Description
<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

- Why is this change required?
- What problem does it solve?
- List any dependencies that are required for this change.
-->

                                                                                                                                  
- The useEffect in ContentOverlayController schedules a requestAnimationFrame but does not cancel it in the cleanup function. If the component unmounts before the next frame fires (e.g. rapidly opening and closing an overlay), the callback still executes and dispatches a stale OPEN action.                           
                     
## Changes
<!-- 
List the specific changes and modifications made in the codebase. Provide details on what was changed, added, or removed.
- Example: Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Example: Added checks to handle cases where the overlay order is modified.
-->

- Added cancelAnimationFrame cleanup in the useEffect of ContentOverlayController to cancel the pending frame on unmount.
  
## Motivation and Context
<!-- 
Explain the context and background for the change. Why is this change necessary? What problem does it address?
-->

-  Without cleanup, a scheduled requestAnimationFrame can fire after the component has already unmounted. 
- This is the standard React cleanup pattern for async scheduling inside useEffect, as described in the https://react.dev/learn/synchronizing-with-effects#how-to-handle-the-effect-firing-twice-in-development. 
- It also prevents duplicate OPEN dispatches under React Strict Mode, which runs effects twice in development.

## How Has This Been Tested?
<!-- 
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
- Example: Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
- Example: Added unit tests to verify the reducer logic for maintaining the correct 'current' overlay.
-->

  - Verified existing unit tests pass locally.
  - Manually confirmed that rapid open/close sequences no longer produce stale dispatches.
  
## Screenshots (if appropriate):
<!-- (Insert screenshots here if relevant) -->

## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have performed a self-review of my own code.
- [ ] My code is commented, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further Comments
<!-- If there are any further comments or questions, please write them here. -->