### PR TITLE
docs: Add `reject` function documentation for `overlay.openAsync`

### DIFF
--- a/docs/src/pages/en/api/utils/overlay-open-async.mdx
+++ b/docs/src/pages/en/api/utils/overlay-open-async.mdx
@@ -32,6 +32,7 @@ overlay.openAsync(({ isOpen, close, unmount }) => {
   - `close`: A function to close the overlay. When you call this function, the value you pass as an argument will be delivered as the resolved value of the `Promise` returned by `overlay.openAsync`, and the overlay will close.
     To allow overlay closing animations to be displayed,
   - `unmount`: Function to remove the overlay. <br/>If called immediately with a closing animation, the component may be removed before the animation completes.
+  - `reject`: When you call this function, the value you pass as an argument will be delivered as the rejected value of the `Promise` returned by `overlay.openAsync`, and the overlay will close.
 - **optional** `options`: Overlay options.
   - `overlayId`: Specify a unique ID when opening the overlay.
 

--- a/docs/src/pages/ko/api/utils/overlay-open-async.mdx
+++ b/docs/src/pages/ko/api/utils/overlay-open-async.mdx
@@ -31,6 +31,7 @@ overlay.openAsync(({ isOpen, close, unmount }) => {
   - `isOpen`: 오버레이가 열렸는지 여부를 나타내는 값이에요.
   - `close`: 오버레이를 닫는 함수예요. 이 함수를 호출 할 때 인자로 전달한 값은 `overlay.openAsync`가 반환하는 `Promise`의 결과 값으로 전달되며 오버레이가 닫혀요. <br/>오버레이 닫기 애니메이션 등을 보여주기 위해서 오버레이 정보는 메모리에 계속 남아있어요. 이것을 완전히 제거하려면 `unmount` 함수를 호출하세요.
   - `unmount`: 오버레이를 제거하는 함수예요. <br/>오버레이 닫기 애니메이션이 있을 때 `unmount`를 바로 호출하면 오버레이가 닫히기 전에 컴포넌트가 제거되어 애니메이션이 제대로 표시되지 않을 수 있어요.
+  - `reject`: 이 함수를 호출 할 때 인자로 전달한 값은 `overlay.openAsync`가 반환하는 `Promise`의 reject 결과로 전달되며 오버레이가 닫혀요.
 - **optional** `options`: 오버레이 옵션입니다.
   - `overlayId`: 오버레이를 열 때 고유한 ID를 지정해요.
 


### PR DESCRIPTION
## Description
This PR supplements the missing 'reject' handler documentation for the controller in the overlay.openAsync method.

**Related PR:** https://github.com/toss/overlay-kit/pull/199

## Changes
<!-- 
List the specific changes and modifications made in the codebase. Provide details on what was changed, added, or removed.
- Example: Modified the reducer logic to ensure 'current' is correctly set to the last overlay when closing an intermediate overlay.
- Example: Added checks to handle cases where the overlay order is modified.
-->

## Motivation and Context
<!-- 
Explain the context and background for the change. Why is this change necessary? What problem does it address?
-->

## How Has This Been Tested?
<!-- 
Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
- Example: Tested by manually opening and closing multiple overlays in various orders to ensure 'current' updates correctly.
-->

## Screenshots (if appropriate):
<!-- (Insert screenshots here if relevant) -->

## Types of changes
<!-- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- 
Go over all the following points, and put an `x` in all the boxes that apply. If you are unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have performed a self-review of my own code.
- [ ] My code is commented, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further Comments
<!-- If there are any further comments or questions, please write them here. -->