### PR TITLE
docs: Add design system integration guides (MUI, Chakra UI, Ant Design)

### DIFF
--- a/docs/src/pages/en/docs/more/_meta.tsx
+++ b/docs/src/pages/en/docs/more/_meta.tsx
@@ -5,4 +5,7 @@ export default {
   'open-outside-react': {
     title: 'Opening Overlays Outside React',
   },
+  'with-design-systems': {
+    title: 'With Design Systems',
+  },
 };

--- a/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
@@ -5,4 +5,7 @@ export default {
   'chakra-ui': {
     title: 'Chakra UI',
   },
+  'ant-design': {
+    title: 'Ant Design',
+  },
 };

--- a/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
@@ -1,0 +1,5 @@
+export default {
+  mui: {
+    title: 'Material UI',
+  },
+};

--- a/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
@@ -2,4 +2,7 @@ export default {
   mui: {
     title: 'Material UI',
   },
+  'chakra-ui': {
+    title: 'Chakra UI',
+  },
 };

--- a/docs/src/pages/en/docs/more/with-design-systems/ant-design.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/ant-design.mdx
@@ -1,0 +1,156 @@
+import { Sandpack } from '@/components';
+
+# With Ant Design
+
+Learn how to use Ant Design's `Modal` component together with `overlay-kit`.
+
+## Installation
+
+Install the `antd` package.
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit antd
+```
+
+## Basic Usage
+
+Ant Design `Modal` uses an `open` prop for visibility plus `onCancel` / `onOk` handlers. Passing `close` to both handlers lets `overlay-kit` manage the state.
+
+<br />
+
+<Sandpack dependencies={{ antd: '^5.22.0' }}>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Button, Modal } from 'antd';
+
+function App() {
+  return (
+    <Button
+      type="primary"
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Modal
+            title="Are you sure you want to continue?"
+            open={isOpen}
+            onCancel={close}
+            onOk={close}
+            cancelText="No"
+            okText="Yes"
+          />
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## Receiving Async Results
+
+With `overlay.openAsync`, you can tell whether the user pressed "OK" or "Cancel" through the resolved `Promise`.
+
+<br />
+
+<Sandpack dependencies={{ antd: '^5.22.0' }}>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Button, Modal } from 'antd';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <div>
+      <p>Result: {result === null ? 'Not selected' : result ? 'Yes' : 'No'}</p>
+      <Button
+        type="primary"
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Modal
+              title="Are you sure you want to continue?"
+              open={isOpen}
+              onCancel={() => close(false)}
+              onOk={() => close(true)}
+              cancelText="No"
+              okText="Yes"
+            />
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Open Confirm Dialog
+      </Button>
+    </div>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## Releasing Memory After Animation
+
+Ant Design `Modal` fires an `afterClose` callback once the close animation completes. Passing `unmount` there keeps the animation visible while safely releasing overlay memory.
+
+<br />
+
+<Sandpack dependencies={{ antd: '^5.22.0' }}>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Button, Modal } from 'antd';
+
+function App() {
+  return (
+    <Button
+      type="primary"
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Modal
+            title="Are you sure you want to continue?"
+            open={isOpen}
+            onCancel={close}
+            onOk={close}
+            afterClose={unmount}
+            cancelText="No"
+            okText="Yes"
+          />
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>

--- a/docs/src/pages/en/docs/more/with-design-systems/chakra-ui.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/chakra-ui.mdx
@@ -1,0 +1,224 @@
+import { Sandpack } from '@/components';
+
+# With Chakra UI
+
+Learn how to use Chakra UI v3's `Dialog` component together with `overlay-kit`.
+
+## Installation
+
+Chakra UI v3 only needs `@emotion/react` (unlike v2, you no longer need `@emotion/styled` or `framer-motion`).
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit @chakra-ui/react @emotion/react
+```
+
+## Basic Usage
+
+Chakra v3's `Dialog.Root` uses `open` and `onOpenChange`. Since `onOpenChange` receives a `{ open: boolean }` object, calling `close()` whenever `!e.open` handles backdrop clicks and ESC dismissal automatically. Wrap the app root in `ChakraProvider value={defaultSystem}`.
+
+<br />
+
+<Sandpack dependencies={{ '@chakra-ui/react': '^3.2.0' }}>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Button,
+  ChakraProvider,
+  Dialog,
+  Portal,
+  defaultSystem,
+} from '@chakra-ui/react';
+
+function App() {
+  return (
+    <Button
+      colorPalette="blue"
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Dialog.Root open={isOpen} onOpenChange={(e) => !e.open && close()}>
+            <Portal>
+              <Dialog.Backdrop />
+              <Dialog.Positioner>
+                <Dialog.Content>
+                  <Dialog.Header>
+                    <Dialog.Title>Are you sure you want to continue?</Dialog.Title>
+                  </Dialog.Header>
+                  <Dialog.Footer gap={2}>
+                    <Button variant="outline" onClick={close}>
+                      No
+                    </Button>
+                    <Button colorPalette="blue" onClick={close}>
+                      Yes
+                    </Button>
+                  </Dialog.Footer>
+                </Dialog.Content>
+              </Dialog.Positioner>
+            </Portal>
+          </Dialog.Root>
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <ChakraProvider value={defaultSystem}>
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
+    </ChakraProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## Receiving Async Results
+
+Use `overlay.openAsync` to capture the user's choice as a `Promise`. Each button passes its own value through `close(value)`.
+
+<br />
+
+<Sandpack dependencies={{ '@chakra-ui/react': '^3.2.0' }}>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Button,
+  ChakraProvider,
+  Dialog,
+  Portal,
+  defaultSystem,
+} from '@chakra-ui/react';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <div>
+      <p>Result: {result === null ? 'Not selected' : result ? 'Yes' : 'No'}</p>
+      <Button
+        colorPalette="blue"
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Dialog.Root open={isOpen} onOpenChange={(e) => !e.open && close(false)}>
+              <Portal>
+                <Dialog.Backdrop />
+                <Dialog.Positioner>
+                  <Dialog.Content>
+                    <Dialog.Header>
+                      <Dialog.Title>Are you sure you want to continue?</Dialog.Title>
+                    </Dialog.Header>
+                    <Dialog.Footer gap={2}>
+                      <Button variant="outline" onClick={() => close(false)}>
+                        No
+                      </Button>
+                      <Button colorPalette="blue" onClick={() => close(true)}>
+                        Yes
+                      </Button>
+                    </Dialog.Footer>
+                  </Dialog.Content>
+                </Dialog.Positioner>
+              </Portal>
+            </Dialog.Root>
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Open Confirm Dialog
+      </Button>
+    </div>
+  );
+}
+
+export function Example() {
+  return (
+    <ChakraProvider value={defaultSystem}>
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
+    </ChakraProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## Releasing Memory After Animation
+
+Unlike MUI's `onExited` or Ant Design's `afterClose`, Chakra v3 `Dialog` doesn't expose a dedicated animation-complete callback. The simplest approach is to call `close()` inside `onOpenChange` and schedule `unmount` with `setTimeout` matching the animation duration. This covers button clicks, backdrop clicks, and ESC dismissal uniformly.
+
+<br />
+
+<Sandpack dependencies={{ '@chakra-ui/react': '^3.2.0' }}>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Button,
+  ChakraProvider,
+  Dialog,
+  Portal,
+  defaultSystem,
+} from '@chakra-ui/react';
+
+function App() {
+  return (
+    <Button
+      colorPalette="blue"
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Dialog.Root
+            open={isOpen}
+            onOpenChange={(e) => {
+              if (!e.open) {
+                close();
+                // Chakra v3's scale animation takes ~200ms.
+                setTimeout(unmount, 200);
+              }
+            }}
+          >
+            <Portal>
+              <Dialog.Backdrop />
+              <Dialog.Positioner>
+                <Dialog.Content>
+                  <Dialog.Header>
+                    <Dialog.Title>Are you sure you want to continue?</Dialog.Title>
+                  </Dialog.Header>
+                  <Dialog.Footer gap={2}>
+                    <Button variant="outline" onClick={close}>
+                      No
+                    </Button>
+                    <Button colorPalette="blue" onClick={close}>
+                      Yes
+                    </Button>
+                  </Dialog.Footer>
+                </Dialog.Content>
+              </Dialog.Positioner>
+            </Portal>
+          </Dialog.Root>
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <ChakraProvider value={defaultSystem}>
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
+    </ChakraProvider>
+  );
+}
+```
+
+</Sandpack>

--- a/docs/src/pages/en/docs/more/with-design-systems/chakra-ui.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/chakra-ui.mdx
@@ -22,13 +22,7 @@ Chakra v3's `Dialog.Root` uses `open` and `onOpenChange`. Since `onOpenChange` r
 
 ```tsx Example.tsx active
 import { OverlayProvider, overlay } from 'overlay-kit';
-import {
-  Button,
-  ChakraProvider,
-  Dialog,
-  Portal,
-  defaultSystem,
-} from '@chakra-ui/react';
+import { Button, ChakraProvider, Dialog, Portal, defaultSystem } from '@chakra-ui/react';
 
 function App() {
   return (
@@ -88,13 +82,7 @@ Use `overlay.openAsync` to capture the user's choice as a `Promise`. Each button
 ```tsx Example.tsx active
 import { useState } from 'react';
 import { OverlayProvider, overlay } from 'overlay-kit';
-import {
-  Button,
-  ChakraProvider,
-  Dialog,
-  Portal,
-  defaultSystem,
-} from '@chakra-ui/react';
+import { Button, ChakraProvider, Dialog, Portal, defaultSystem } from '@chakra-ui/react';
 
 function App() {
   const [result, setResult] = useState<boolean | null>(null);
@@ -159,13 +147,7 @@ Unlike MUI's `onExited` or Ant Design's `afterClose`, Chakra v3 `Dialog` doesn't
 
 ```tsx Example.tsx active
 import { OverlayProvider, overlay } from 'overlay-kit';
-import {
-  Button,
-  ChakraProvider,
-  Dialog,
-  Portal,
-  defaultSystem,
-} from '@chakra-ui/react';
+import { Button, ChakraProvider, Dialog, Portal, defaultSystem } from '@chakra-ui/react';
 
 function App() {
   return (

--- a/docs/src/pages/en/docs/more/with-design-systems/mui.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/mui.mdx
@@ -134,11 +134,7 @@ function App() {
       variant="contained"
       onClick={() => {
         overlay.open(({ isOpen, close, unmount }) => (
-          <Dialog
-            open={isOpen}
-            onClose={close}
-            TransitionProps={{ onExited: unmount }}
-          >
+          <Dialog open={isOpen} onClose={close} TransitionProps={{ onExited: unmount }}>
             <DialogTitle>Are you sure you want to continue?</DialogTitle>
             <DialogActions>
               <Button onClick={close}>No</Button>

--- a/docs/src/pages/en/docs/more/with-design-systems/mui.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/mui.mdx
@@ -1,0 +1,165 @@
+import { Sandpack } from '@/components';
+
+# With Material UI
+
+Learn how to use Material UI(MUI)'s `Dialog` component together with `overlay-kit`.
+
+## Installation
+
+Install MUI along with its emotion peer dependencies.
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit @mui/material @emotion/react @emotion/styled
+```
+
+## Basic Usage
+
+MUI `Dialog` takes an `open` prop for visibility and `onClose` for dismissal. You can pass `isOpen` and `close` from `overlay-kit` directly.
+
+<br />
+
+<Sandpack>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogActions from '@mui/material/DialogActions';
+
+function App() {
+  return (
+    <Button
+      variant="contained"
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Dialog open={isOpen} onClose={close}>
+            <DialogTitle>Are you sure you want to continue?</DialogTitle>
+            <DialogActions>
+              <Button onClick={close}>No</Button>
+              <Button onClick={close}>Yes</Button>
+            </DialogActions>
+          </Dialog>
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## Receiving Async Results
+
+Use `overlay.openAsync` to receive the user's choice as a `Promise`. Pass the result through `close(value)` so "Yes" resolves to `true` and "No" to `false`.
+
+<br />
+
+<Sandpack>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogActions from '@mui/material/DialogActions';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <div>
+      <p>Result: {result === null ? 'Not selected' : result ? 'Yes' : 'No'}</p>
+      <Button
+        variant="contained"
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Dialog open={isOpen} onClose={() => close(false)}>
+              <DialogTitle>Are you sure you want to continue?</DialogTitle>
+              <DialogActions>
+                <Button onClick={() => close(false)}>No</Button>
+                <Button onClick={() => close(true)}>Yes</Button>
+              </DialogActions>
+            </Dialog>
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Open Confirm Dialog
+      </Button>
+    </div>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## Releasing Memory After Animation
+
+MUI `Dialog` exposes `TransitionProps.onExited`, which fires after the close animation completes. Pass `unmount` there to safely release overlay memory while preserving the exit animation.
+
+<br />
+
+<Sandpack>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogActions from '@mui/material/DialogActions';
+
+function App() {
+  return (
+    <Button
+      variant="contained"
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Dialog
+            open={isOpen}
+            onClose={close}
+            TransitionProps={{ onExited: unmount }}
+          >
+            <DialogTitle>Are you sure you want to continue?</DialogTitle>
+            <DialogActions>
+              <Button onClick={close}>No</Button>
+              <Button onClick={close}>Yes</Button>
+            </DialogActions>
+          </Dialog>
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>

--- a/docs/src/pages/ko/docs/more/_meta.tsx
+++ b/docs/src/pages/ko/docs/more/_meta.tsx
@@ -5,4 +5,7 @@ export default {
   'open-outside-react': {
     title: 'React 외부에서 오버레이 열기',
   },
+  'with-design-systems': {
+    title: '디자인 시스템과 함께 쓰기',
+  },
 };

--- a/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
@@ -5,4 +5,7 @@ export default {
   'chakra-ui': {
     title: 'Chakra UI',
   },
+  'ant-design': {
+    title: 'Ant Design',
+  },
 };

--- a/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
@@ -1,0 +1,5 @@
+export default {
+  mui: {
+    title: 'Material UI',
+  },
+};

--- a/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
@@ -2,4 +2,7 @@ export default {
   mui: {
     title: 'Material UI',
   },
+  'chakra-ui': {
+    title: 'Chakra UI',
+  },
 };

--- a/docs/src/pages/ko/docs/more/with-design-systems/ant-design.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/ant-design.mdx
@@ -1,0 +1,156 @@
+import { Sandpack } from '@/components';
+
+# Ant Design과 함께 쓰기
+
+Ant Design의 `Modal` 컴포넌트를 `overlay-kit`과 함께 사용하는 방법을 알아볼게요.
+
+## 설치
+
+`antd` 패키지를 설치해요.
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit antd
+```
+
+## 기본 사용법
+
+Ant Design `Modal`은 `open` prop으로 열림 상태를, `onCancel`과 `onOk`로 각 액션을 처리해요. 두 이벤트 모두 `close`를 전달하면 `overlay-kit`이 상태를 관리해줘요.
+
+<br />
+
+<Sandpack dependencies={{ antd: '^5.22.0' }}>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Button, Modal } from 'antd';
+
+function App() {
+  return (
+    <Button
+      type="primary"
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Modal
+            title="정말로 계속하시겠어요?"
+            open={isOpen}
+            onCancel={close}
+            onOk={close}
+            cancelText="아니요"
+            okText="네"
+          />
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## 비동기 결과 받기
+
+`overlay.openAsync`를 사용하면 사용자가 "확인"을 눌렀는지 "취소"를 눌렀는지 `Promise` 결과로 받을 수 있어요.
+
+<br />
+
+<Sandpack dependencies={{ antd: '^5.22.0' }}>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Button, Modal } from 'antd';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <div>
+      <p>결과: {result === null ? '선택 없음' : result ? '네' : '아니요'}</p>
+      <Button
+        type="primary"
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Modal
+              title="정말로 계속하시겠어요?"
+              open={isOpen}
+              onCancel={() => close(false)}
+              onOk={() => close(true)}
+              cancelText="아니요"
+              okText="네"
+            />
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Confirm Dialog 열기
+      </Button>
+    </div>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## 애니메이션 후 메모리 해제
+
+Ant Design `Modal`은 닫기 애니메이션이 끝난 뒤에 실행되는 `afterClose` 콜백을 제공해요. 여기에 `unmount`를 전달하면 애니메이션을 유지하면서 메모리를 안전하게 해제할 수 있어요.
+
+<br />
+
+<Sandpack dependencies={{ antd: '^5.22.0' }}>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Button, Modal } from 'antd';
+
+function App() {
+  return (
+    <Button
+      type="primary"
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Modal
+            title="정말로 계속하시겠어요?"
+            open={isOpen}
+            onCancel={close}
+            onOk={close}
+            afterClose={unmount}
+            cancelText="아니요"
+            okText="네"
+          />
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>

--- a/docs/src/pages/ko/docs/more/with-design-systems/chakra-ui.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/chakra-ui.mdx
@@ -22,13 +22,7 @@ Chakra v3의 `Dialog.Root`는 `open`과 `onOpenChange`를 사용해요. `onOpenC
 
 ```tsx Example.tsx active
 import { OverlayProvider, overlay } from 'overlay-kit';
-import {
-  Button,
-  ChakraProvider,
-  Dialog,
-  Portal,
-  defaultSystem,
-} from '@chakra-ui/react';
+import { Button, ChakraProvider, Dialog, Portal, defaultSystem } from '@chakra-ui/react';
 
 function App() {
   return (
@@ -88,13 +82,7 @@ export function Example() {
 ```tsx Example.tsx active
 import { useState } from 'react';
 import { OverlayProvider, overlay } from 'overlay-kit';
-import {
-  Button,
-  ChakraProvider,
-  Dialog,
-  Portal,
-  defaultSystem,
-} from '@chakra-ui/react';
+import { Button, ChakraProvider, Dialog, Portal, defaultSystem } from '@chakra-ui/react';
 
 function App() {
   const [result, setResult] = useState<boolean | null>(null);
@@ -159,13 +147,7 @@ Chakra v3 `Dialog`는 MUI의 `onExited`나 Ant Design의 `afterClose` 같은 애
 
 ```tsx Example.tsx active
 import { OverlayProvider, overlay } from 'overlay-kit';
-import {
-  Button,
-  ChakraProvider,
-  Dialog,
-  Portal,
-  defaultSystem,
-} from '@chakra-ui/react';
+import { Button, ChakraProvider, Dialog, Portal, defaultSystem } from '@chakra-ui/react';
 
 function App() {
   return (

--- a/docs/src/pages/ko/docs/more/with-design-systems/chakra-ui.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/chakra-ui.mdx
@@ -1,0 +1,224 @@
+import { Sandpack } from '@/components';
+
+# Chakra UI와 함께 쓰기
+
+Chakra UI v3의 `Dialog` 컴포넌트를 `overlay-kit`과 함께 사용하는 방법을 알아볼게요.
+
+## 설치
+
+Chakra UI v3는 `@emotion/react`만 있으면 돼요. (v2와 달리 `@emotion/styled`, `framer-motion`은 필요 없어요)
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit @chakra-ui/react @emotion/react
+```
+
+## 기본 사용법
+
+Chakra v3의 `Dialog.Root`는 `open`과 `onOpenChange`를 사용해요. `onOpenChange`는 `{ open: boolean }` 형태의 객체를 넘겨주기 때문에 `!e.open`일 때 `close`를 호출해주면 backdrop 클릭·ESC 키로 닫히는 경우까지 자연스럽게 처리돼요. 앱 루트는 `ChakraProvider value={defaultSystem}`으로 감싸야 해요.
+
+<br />
+
+<Sandpack dependencies={{ '@chakra-ui/react': '^3.2.0' }}>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Button,
+  ChakraProvider,
+  Dialog,
+  Portal,
+  defaultSystem,
+} from '@chakra-ui/react';
+
+function App() {
+  return (
+    <Button
+      colorPalette="blue"
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Dialog.Root open={isOpen} onOpenChange={(e) => !e.open && close()}>
+            <Portal>
+              <Dialog.Backdrop />
+              <Dialog.Positioner>
+                <Dialog.Content>
+                  <Dialog.Header>
+                    <Dialog.Title>정말로 계속하시겠어요?</Dialog.Title>
+                  </Dialog.Header>
+                  <Dialog.Footer gap={2}>
+                    <Button variant="outline" onClick={close}>
+                      아니요
+                    </Button>
+                    <Button colorPalette="blue" onClick={close}>
+                      네
+                    </Button>
+                  </Dialog.Footer>
+                </Dialog.Content>
+              </Dialog.Positioner>
+            </Portal>
+          </Dialog.Root>
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <ChakraProvider value={defaultSystem}>
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
+    </ChakraProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## 비동기 결과 받기
+
+`overlay.openAsync`로 사용자의 선택을 `Promise`로 받을 수 있어요. 각 버튼에서 `close(value)`로 결과를 넘기면 돼요.
+
+<br />
+
+<Sandpack dependencies={{ '@chakra-ui/react': '^3.2.0' }}>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Button,
+  ChakraProvider,
+  Dialog,
+  Portal,
+  defaultSystem,
+} from '@chakra-ui/react';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <div>
+      <p>결과: {result === null ? '선택 없음' : result ? '네' : '아니요'}</p>
+      <Button
+        colorPalette="blue"
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Dialog.Root open={isOpen} onOpenChange={(e) => !e.open && close(false)}>
+              <Portal>
+                <Dialog.Backdrop />
+                <Dialog.Positioner>
+                  <Dialog.Content>
+                    <Dialog.Header>
+                      <Dialog.Title>정말로 계속하시겠어요?</Dialog.Title>
+                    </Dialog.Header>
+                    <Dialog.Footer gap={2}>
+                      <Button variant="outline" onClick={() => close(false)}>
+                        아니요
+                      </Button>
+                      <Button colorPalette="blue" onClick={() => close(true)}>
+                        네
+                      </Button>
+                    </Dialog.Footer>
+                  </Dialog.Content>
+                </Dialog.Positioner>
+              </Portal>
+            </Dialog.Root>
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Confirm Dialog 열기
+      </Button>
+    </div>
+  );
+}
+
+export function Example() {
+  return (
+    <ChakraProvider value={defaultSystem}>
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
+    </ChakraProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## 애니메이션 후 메모리 해제
+
+Chakra v3 `Dialog`는 MUI의 `onExited`나 Ant Design의 `afterClose` 같은 애니메이션 완료 콜백을 직접 제공하지 않아요. 대신 `onOpenChange`에서 `close`를 호출한 뒤 애니메이션 지속 시간만큼 `setTimeout`으로 `unmount`를 예약하는 방식이 가장 간단해요. 버튼 클릭뿐만 아니라 backdrop 클릭·ESC 키로 닫히는 경우도 모두 처리돼요.
+
+<br />
+
+<Sandpack dependencies={{ '@chakra-ui/react': '^3.2.0' }}>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Button,
+  ChakraProvider,
+  Dialog,
+  Portal,
+  defaultSystem,
+} from '@chakra-ui/react';
+
+function App() {
+  return (
+    <Button
+      colorPalette="blue"
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Dialog.Root
+            open={isOpen}
+            onOpenChange={(e) => {
+              if (!e.open) {
+                close();
+                // Chakra v3 scale 애니메이션이 약 200ms 걸려요.
+                setTimeout(unmount, 200);
+              }
+            }}
+          >
+            <Portal>
+              <Dialog.Backdrop />
+              <Dialog.Positioner>
+                <Dialog.Content>
+                  <Dialog.Header>
+                    <Dialog.Title>정말로 계속하시겠어요?</Dialog.Title>
+                  </Dialog.Header>
+                  <Dialog.Footer gap={2}>
+                    <Button variant="outline" onClick={close}>
+                      아니요
+                    </Button>
+                    <Button colorPalette="blue" onClick={close}>
+                      네
+                    </Button>
+                  </Dialog.Footer>
+                </Dialog.Content>
+              </Dialog.Positioner>
+            </Portal>
+          </Dialog.Root>
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <ChakraProvider value={defaultSystem}>
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
+    </ChakraProvider>
+  );
+}
+```
+
+</Sandpack>

--- a/docs/src/pages/ko/docs/more/with-design-systems/mui.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/mui.mdx
@@ -1,0 +1,165 @@
+import { Sandpack } from '@/components';
+
+# Material UI와 함께 쓰기
+
+Material UI(MUI)의 `Dialog` 컴포넌트를 `overlay-kit`과 함께 사용하는 방법을 알아볼게요.
+
+## 설치
+
+MUI와 emotion 패키지를 함께 설치해요.
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit @mui/material @emotion/react @emotion/styled
+```
+
+## 기본 사용법
+
+MUI `Dialog`는 `open` prop으로 열림 상태를 받고, `onClose`로 닫기 이벤트를 처리해요. `overlay-kit`에서 제공하는 `isOpen`과 `close`를 그대로 전달하면 돼요.
+
+<br />
+
+<Sandpack>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogActions from '@mui/material/DialogActions';
+
+function App() {
+  return (
+    <Button
+      variant="contained"
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Dialog open={isOpen} onClose={close}>
+            <DialogTitle>정말로 계속하시겠어요?</DialogTitle>
+            <DialogActions>
+              <Button onClick={close}>아니요</Button>
+              <Button onClick={close}>네</Button>
+            </DialogActions>
+          </Dialog>
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## 비동기 결과 받기
+
+`overlay.openAsync`로 사용자의 선택 결과를 `Promise`로 받을 수 있어요. "네"를 누르면 `true`, "아니요"를 누르면 `false`가 반환되도록 `close` 함수에 값을 전달해요.
+
+<br />
+
+<Sandpack>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogActions from '@mui/material/DialogActions';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <div>
+      <p>결과: {result === null ? '선택 없음' : result ? '네' : '아니요'}</p>
+      <Button
+        variant="contained"
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Dialog open={isOpen} onClose={() => close(false)}>
+              <DialogTitle>정말로 계속하시겠어요?</DialogTitle>
+              <DialogActions>
+                <Button onClick={() => close(false)}>아니요</Button>
+                <Button onClick={() => close(true)}>네</Button>
+              </DialogActions>
+            </Dialog>
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Confirm Dialog 열기
+      </Button>
+    </div>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## 애니메이션 후 메모리 해제
+
+MUI `Dialog`는 `TransitionProps.onExited` 콜백을 통해 닫기 애니메이션이 끝나는 시점을 알려줘요. 여기에 `unmount`를 전달하면 애니메이션을 보여주면서도 오버레이 메모리를 안전하게 해제할 수 있어요.
+
+<br />
+
+<Sandpack>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogActions from '@mui/material/DialogActions';
+
+function App() {
+  return (
+    <Button
+      variant="contained"
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Dialog
+            open={isOpen}
+            onClose={close}
+            TransitionProps={{ onExited: unmount }}
+          >
+            <DialogTitle>정말로 계속하시겠어요?</DialogTitle>
+            <DialogActions>
+              <Button onClick={close}>아니요</Button>
+              <Button onClick={close}>네</Button>
+            </DialogActions>
+          </Dialog>
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>

--- a/docs/src/pages/ko/docs/more/with-design-systems/mui.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/mui.mdx
@@ -134,11 +134,7 @@ function App() {
       variant="contained"
       onClick={() => {
         overlay.open(({ isOpen, close, unmount }) => (
-          <Dialog
-            open={isOpen}
-            onClose={close}
-            TransitionProps={{ onExited: unmount }}
-          >
+          <Dialog open={isOpen} onClose={close} TransitionProps={{ onExited: unmount }}>
             <DialogTitle>정말로 계속하시겠어요?</DialogTitle>
             <DialogActions>
               <Button onClick={close}>아니요</Button>


### PR DESCRIPTION
## Description

Adds a new "디자인 시스템과 함께 쓰기 / With Design Systems" section under `docs/more` with runnable Sandpack examples showing how to integrate overlay-kit with popular React UI libraries.

**Related Issue:** N/A (proactive documentation improvement)

## Changes

- Register a new documentation section `docs/more/with-design-systems` in the sidebar for both `ko` and `en` locales (`_meta.tsx` updates).
- Add Material UI example (`mui.mdx`) — `Dialog` with `open`/`onClose`, memory release via `TransitionProps.onExited`.
- Add Chakra UI v3 example (`chakra-ui.mdx`) — `Dialog.Root` with `onOpenChange`, memory release via `setTimeout` matching the scale motion preset (Chakra v3 does not expose an exit-complete callback).
- Add Ant Design example (`ant-design.mdx`) — `Modal` with `onCancel`/`onOk`, memory release via `afterClose`.
- Each page covers three patterns consistent with existing docs: basic `overlay.open`, async `overlay.openAsync`, and memory release after the exit animation.

## Motivation and Context

The existing docs demonstrate overlay-kit paired with MUI (in the introduction and `more/basic` pages), but users adopting other popular design systems have to reverse-engineer how each library's `open`/`onClose` and exit-animation callbacks map to overlay-kit's `isOpen`, `close`, and `unmount`. This PR lowers that friction by providing runnable reference examples for the most commonly requested libraries, keeping the docs style and Sandpack structure already established by `more/basic`.

## How Has This Been Tested?

- Ran \`yarn dev\` in \`docs/\` and verified all three new pages compile and render (HTTP 200) at:
  - \`/ko/docs/more/with-design-systems/mui\`
  - \`/ko/docs/more/with-design-systems/chakra-ui\`
  - \`/ko/docs/more/with-design-systems/ant-design\`
- Verified the English counterparts compile the same way.
- Verified the sidebar navigation shows the new section and entries in the expected order for both locales.

## Screenshots (if appropriate)

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have performed a self-review of my own code.
- [x] My code is commented, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Further Comments

Commits are split per library so each integration guide can be reviewed (or reverted) independently.