### PR TITLE
docs: Add shadcn/ui, Radix UI, Mantine, and Headless UI integration guides

### DIFF
--- a/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
@@ -17,4 +17,7 @@ export default {
   mantine: {
     title: 'Mantine',
   },
+  'headless-ui': {
+    title: 'Headless UI',
+  },
 };

--- a/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
@@ -8,4 +8,7 @@ export default {
   'ant-design': {
     title: 'Ant Design',
   },
+  shadcn: {
+    title: 'shadcn/ui',
+  },
 };

--- a/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
@@ -14,4 +14,7 @@ export default {
   'radix-ui': {
     title: 'Radix UI',
   },
+  mantine: {
+    title: 'Mantine',
+  },
 };

--- a/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/en/docs/more/with-design-systems/_meta.tsx
@@ -11,4 +11,7 @@ export default {
   shadcn: {
     title: 'shadcn/ui',
   },
+  'radix-ui': {
+    title: 'Radix UI',
+  },
 };

--- a/docs/src/pages/en/docs/more/with-design-systems/chakra-ui.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/chakra-ui.mdx
@@ -6,7 +6,7 @@ Learn how to use Chakra UI v3's `Dialog` component together with `overlay-kit`.
 
 ## Installation
 
-Chakra UI v3 only needs `@emotion/react` (unlike v2, you no longer need `@emotion/styled` or `framer-motion`).
+Chakra UI only needs `@emotion/react`.
 
 ```sh npm2yarn filename="shell" copy
 npm install overlay-kit @chakra-ui/react @emotion/react
@@ -139,7 +139,7 @@ export function Example() {
 
 ## Releasing Memory After Animation
 
-Unlike MUI's `onExited` or Ant Design's `afterClose`, Chakra v3 `Dialog` doesn't expose a dedicated animation-complete callback. The simplest approach is to call `close()` inside `onOpenChange` and schedule `unmount` with `setTimeout` matching the animation duration. This covers button clicks, backdrop clicks, and ESC dismissal uniformly.
+Chakra `Dialog` doesn't expose a dedicated animation-complete callback. The simplest approach is to call `close()` inside `onOpenChange` and schedule `unmount` with `setTimeout` matching the animation duration. This covers button clicks, backdrop clicks, and ESC dismissal uniformly.
 
 <br />
 

--- a/docs/src/pages/en/docs/more/with-design-systems/headless-ui.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/headless-ui.mdx
@@ -1,0 +1,252 @@
+import { Sandpack } from '@/components';
+
+# With Headless UI
+
+Learn how to use Headless UI's `Dialog` component together with `overlay-kit`.
+
+## Installation
+
+Since Headless UI ships unstyled headless primitives, the examples below pair it with Tailwind CSS.
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit @headlessui/react
+```
+
+## Basic Usage
+
+Headless UI `Dialog` takes an `open` prop for visibility and `onClose` for dismissal. `onClose` is invoked automatically on backdrop clicks and Escape key presses, so you can pass `close` directly.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@headlessui/react': '^2.2.0',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle, Description } from '@headlessui/react';
+
+function App() {
+  return (
+    <button
+      className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Dialog open={isOpen} onClose={close} className="relative z-50">
+            <DialogBackdrop className="fixed inset-0 bg-black/50" />
+            <div className="fixed inset-0 flex items-center justify-center p-4">
+              <DialogPanel className="w-full max-w-md space-y-4 rounded-lg bg-white p-6 shadow-xl">
+                <DialogTitle className="text-lg font-semibold">Are you sure you want to continue?</DialogTitle>
+                <Description className="text-sm text-gray-500">This action cannot be undone.</Description>
+                <div className="flex justify-end gap-2">
+                  <button
+                    className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                    onClick={close}
+                  >
+                    No
+                  </button>
+                  <button
+                    className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                    onClick={close}
+                  >
+                    Yes
+                  </button>
+                </div>
+              </DialogPanel>
+            </div>
+          </Dialog>
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## Receiving Async Results
+
+Use `overlay.openAsync` to receive the user's choice as a `Promise`. Pass the result through `close(value)` on each button, and provide a default value in `onClose` for backdrop or Escape dismissal.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@headlessui/react': '^2.2.0',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle, Description } from '@headlessui/react';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <div>
+      <p className="mb-2 text-sm">Result: {result === null ? 'Not selected' : result ? 'Yes' : 'No'}</p>
+      <button
+        className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Dialog open={isOpen} onClose={() => close(false)} className="relative z-50">
+              <DialogBackdrop className="fixed inset-0 bg-black/50" />
+              <div className="fixed inset-0 flex items-center justify-center p-4">
+                <DialogPanel className="w-full max-w-md space-y-4 rounded-lg bg-white p-6 shadow-xl">
+                  <DialogTitle className="text-lg font-semibold">Are you sure you want to continue?</DialogTitle>
+                  <Description className="text-sm text-gray-500">This action cannot be undone.</Description>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                      onClick={() => close(false)}
+                    >
+                      No
+                    </button>
+                    <button
+                      className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                      onClick={() => close(true)}
+                    >
+                      Yes
+                    </button>
+                  </div>
+                </DialogPanel>
+              </div>
+            </Dialog>
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Open Confirm Dialog
+      </button>
+    </div>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## Releasing Memory After Animation
+
+Headless UI `Dialog` does not handle transitions on its own and is typically wrapped with `<Transition>`. Passing `unmount` to the `<Transition>`'s `afterLeave` callback releases overlay memory safely right after the close animation finishes.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@headlessui/react': '^2.2.0',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { Fragment } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+  Description,
+  Transition,
+  TransitionChild,
+} from '@headlessui/react';
+
+function App() {
+  return (
+    <button
+      className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Transition show={isOpen} as={Fragment} afterLeave={unmount}>
+            <Dialog onClose={close} className="relative z-50">
+              <TransitionChild
+                as={Fragment}
+                enter="ease-out duration-200"
+                enterFrom="opacity-0"
+                enterTo="opacity-100"
+                leave="ease-in duration-150"
+                leaveFrom="opacity-100"
+                leaveTo="opacity-0"
+              >
+                <DialogBackdrop className="fixed inset-0 bg-black/50" />
+              </TransitionChild>
+              <div className="fixed inset-0 flex items-center justify-center p-4">
+                <TransitionChild
+                  as={Fragment}
+                  enter="ease-out duration-200"
+                  enterFrom="opacity-0 scale-95"
+                  enterTo="opacity-100 scale-100"
+                  leave="ease-in duration-150"
+                  leaveFrom="opacity-100 scale-100"
+                  leaveTo="opacity-0 scale-95"
+                >
+                  <DialogPanel className="w-full max-w-md space-y-4 rounded-lg bg-white p-6 shadow-xl">
+                    <DialogTitle className="text-lg font-semibold">Are you sure you want to continue?</DialogTitle>
+                    <Description className="text-sm text-gray-500">This action cannot be undone.</Description>
+                    <div className="flex justify-end gap-2">
+                      <button
+                        className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                        onClick={close}
+                      >
+                        No
+                      </button>
+                      <button
+                        className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                        onClick={close}
+                      >
+                        Yes
+                      </button>
+                    </div>
+                  </DialogPanel>
+                </TransitionChild>
+              </div>
+            </Dialog>
+          </Transition>
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>

--- a/docs/src/pages/en/docs/more/with-design-systems/mantine.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/mantine.mdx
@@ -1,0 +1,181 @@
+import { Sandpack } from '@/components';
+
+# With Mantine
+
+Learn how to use Mantine's `Modal` component together with `overlay-kit`.
+
+## Installation
+
+Install the Mantine core and hooks packages, and import the stylesheet at the root of your app.
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit @mantine/core @mantine/hooks
+```
+
+## Basic Usage
+
+Mantine `Modal` takes an `opened` prop for visibility and `onClose` for dismissal. Wrap your app with `MantineProvider` and import `@mantine/core/styles.css` so the modal renders correctly.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@mantine/core': '^7.13.0',
+    '@mantine/hooks': '^7.13.0',
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Button, MantineProvider, Modal, Group } from '@mantine/core';
+import '@mantine/core/styles.css';
+
+function App() {
+  return (
+    <Button
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Modal opened={isOpen} onClose={close} title="Are you sure you want to continue?">
+            <Group justify="flex-end" gap="sm">
+              <Button variant="default" onClick={close}>
+                No
+              </Button>
+              <Button onClick={close}>Yes</Button>
+            </Group>
+          </Modal>
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <MantineProvider>
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
+    </MantineProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## Receiving Async Results
+
+Use `overlay.openAsync` to receive the user's choice as a `Promise`. Pass the result through `close(value)` on each button, and provide a default value in `onClose` for backdrop or Escape dismissal.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@mantine/core': '^7.13.0',
+    '@mantine/hooks': '^7.13.0',
+  }}
+>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Button, MantineProvider, Modal, Group, Text } from '@mantine/core';
+import '@mantine/core/styles.css';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <Group align="center" gap="md">
+      <Text size="sm">Result: {result === null ? 'Not selected' : result ? 'Yes' : 'No'}</Text>
+      <Button
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Modal opened={isOpen} onClose={() => close(false)} title="Are you sure you want to continue?">
+              <Group justify="flex-end" gap="sm">
+                <Button variant="default" onClick={() => close(false)}>
+                  No
+                </Button>
+                <Button onClick={() => close(true)}>Yes</Button>
+              </Group>
+            </Modal>
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Open Confirm Dialog
+      </Button>
+    </Group>
+  );
+}
+
+export function Example() {
+  return (
+    <MantineProvider>
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
+    </MantineProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## Releasing Memory After Animation
+
+Mantine `Modal` accepts transition callbacks via `transitionProps`. Passing `unmount` to `transitionProps.onExited` releases overlay memory safely right after the close animation completes.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@mantine/core': '^7.13.0',
+    '@mantine/hooks': '^7.13.0',
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Button, MantineProvider, Modal, Group } from '@mantine/core';
+import '@mantine/core/styles.css';
+
+function App() {
+  return (
+    <Button
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Modal
+            opened={isOpen}
+            onClose={close}
+            title="Are you sure you want to continue?"
+            transitionProps={{ onExited: unmount }}
+          >
+            <Group justify="flex-end" gap="sm">
+              <Button variant="default" onClick={close}>
+                No
+              </Button>
+              <Button onClick={close}>Yes</Button>
+            </Group>
+          </Modal>
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <MantineProvider>
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
+    </MantineProvider>
+  );
+}
+```
+
+</Sandpack>

--- a/docs/src/pages/en/docs/more/with-design-systems/radix-ui.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/radix-ui.mdx
@@ -1,0 +1,236 @@
+import { Sandpack } from '@/components';
+
+# With Radix UI
+
+Learn how to use Radix UI's `Dialog` primitives together with `overlay-kit`.
+
+## Installation
+
+Install the Radix `Dialog` package. Since Radix UI ships unstyled headless primitives, the examples below pair it with Tailwind CSS.
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit @radix-ui/react-dialog
+```
+
+## Basic Usage
+
+Radix `Dialog.Root` takes an `open` prop for visibility and `onOpenChange` for dismissal. `onOpenChange` receives a `boolean`, so calling `close()` when `!open` covers backdrop clicks and the Escape key naturally.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@radix-ui/react-dialog': '^1.1.6',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import * as Dialog from '@radix-ui/react-dialog';
+
+function App() {
+  return (
+    <button
+      className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Dialog.Root open={isOpen} onOpenChange={(open) => !open && close()}>
+            <Dialog.Portal>
+              <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+              <Dialog.Content className="fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-white p-6 shadow-lg">
+                <Dialog.Title className="text-lg font-semibold">Are you sure you want to continue?</Dialog.Title>
+                <Dialog.Description className="text-sm text-gray-500">
+                  This action cannot be undone.
+                </Dialog.Description>
+                <div className="flex justify-end gap-2">
+                  <button
+                    className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                    onClick={close}
+                  >
+                    No
+                  </button>
+                  <button
+                    className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+                    onClick={close}
+                  >
+                    Yes
+                  </button>
+                </div>
+              </Dialog.Content>
+            </Dialog.Portal>
+          </Dialog.Root>
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## Receiving Async Results
+
+Use `overlay.openAsync` to receive the user's choice as a `Promise`. Pass the result through `close(value)` on each button, and provide a default value when the dialog is dismissed via backdrop or Escape.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@radix-ui/react-dialog': '^1.1.6',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import * as Dialog from '@radix-ui/react-dialog';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <div>
+      <p className="mb-2 text-sm">Result: {result === null ? 'Not selected' : result ? 'Yes' : 'No'}</p>
+      <button
+        className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Dialog.Root open={isOpen} onOpenChange={(open) => !open && close(false)}>
+              <Dialog.Portal>
+                <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+                <Dialog.Content className="fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-white p-6 shadow-lg">
+                  <Dialog.Title className="text-lg font-semibold">Are you sure you want to continue?</Dialog.Title>
+                  <Dialog.Description className="text-sm text-gray-500">
+                    This action cannot be undone.
+                  </Dialog.Description>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                      onClick={() => close(false)}
+                    >
+                      No
+                    </button>
+                    <button
+                      className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+                      onClick={() => close(true)}
+                    >
+                      Yes
+                    </button>
+                  </div>
+                </Dialog.Content>
+              </Dialog.Portal>
+            </Dialog.Root>
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Open Confirm Dialog
+      </button>
+    </div>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## Releasing Memory After Animation
+
+Radix `Dialog` does not expose a callback like MUI's `onExited` or Ant Design's `afterClose`. Instead, call `close` in `onOpenChange` and schedule `unmount` with `setTimeout` for the animation duration. This handles button clicks, backdrop clicks, and the Escape key uniformly.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@radix-ui/react-dialog': '^1.1.6',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import * as Dialog from '@radix-ui/react-dialog';
+
+function App() {
+  return (
+    <button
+      className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Dialog.Root
+            open={isOpen}
+            onOpenChange={(open) => {
+              if (!open) {
+                close();
+                // Radix dialog's close animation is around 150ms.
+                setTimeout(unmount, 200);
+              }
+            }}
+          >
+            <Dialog.Portal>
+              <Dialog.Overlay className="fixed inset-0 bg-black/50 transition-opacity data-[state=closed]:opacity-0 data-[state=open]:opacity-100" />
+              <Dialog.Content className="fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-white p-6 shadow-lg transition-opacity data-[state=closed]:opacity-0 data-[state=open]:opacity-100">
+                <Dialog.Title className="text-lg font-semibold">Are you sure you want to continue?</Dialog.Title>
+                <Dialog.Description className="text-sm text-gray-500">
+                  This action cannot be undone.
+                </Dialog.Description>
+                <div className="flex justify-end gap-2">
+                  <button
+                    className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                    onClick={close}
+                  >
+                    No
+                  </button>
+                  <button
+                    className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+                    onClick={close}
+                  >
+                    Yes
+                  </button>
+                </div>
+              </Dialog.Content>
+            </Dialog.Portal>
+          </Dialog.Root>
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>

--- a/docs/src/pages/en/docs/more/with-design-systems/radix-ui.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/radix-ui.mdx
@@ -159,7 +159,7 @@ export function Example() {
 
 ## Releasing Memory After Animation
 
-Radix `Dialog` does not expose a callback like MUI's `onExited` or Ant Design's `afterClose`. Instead, call `close` in `onOpenChange` and schedule `unmount` with `setTimeout` for the animation duration. This handles button clicks, backdrop clicks, and the Escape key uniformly.
+Radix `Dialog` does not expose a dedicated animation-complete callback. Call `close` in `onOpenChange` and schedule `unmount` with `setTimeout` for the animation duration. This handles button clicks, backdrop clicks, and the Escape key uniformly.
 
 <br />
 

--- a/docs/src/pages/en/docs/more/with-design-systems/radix-ui.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/radix-ui.mdx
@@ -42,9 +42,7 @@ function App() {
               <Dialog.Overlay className="fixed inset-0 bg-black/50" />
               <Dialog.Content className="fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-white p-6 shadow-lg">
                 <Dialog.Title className="text-lg font-semibold">Are you sure you want to continue?</Dialog.Title>
-                <Dialog.Description className="text-sm text-gray-500">
-                  This action cannot be undone.
-                </Dialog.Description>
+                <Dialog.Description className="text-sm text-gray-500">This action cannot be undone.</Dialog.Description>
                 <div className="flex justify-end gap-2">
                   <button
                     className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
@@ -196,9 +194,7 @@ function App() {
               <Dialog.Overlay className="fixed inset-0 bg-black/50 transition-opacity data-[state=closed]:opacity-0 data-[state=open]:opacity-100" />
               <Dialog.Content className="fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-white p-6 shadow-lg transition-opacity data-[state=closed]:opacity-0 data-[state=open]:opacity-100">
                 <Dialog.Title className="text-lg font-semibold">Are you sure you want to continue?</Dialog.Title>
-                <Dialog.Description className="text-sm text-gray-500">
-                  This action cannot be undone.
-                </Dialog.Description>
+                <Dialog.Description className="text-sm text-gray-500">This action cannot be undone.</Dialog.Description>
                 <div className="flex justify-end gap-2">
                   <button
                     className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"

--- a/docs/src/pages/en/docs/more/with-design-systems/shadcn.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/shadcn.mdx
@@ -360,7 +360,7 @@ DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 ## Releasing Memory After Animation
 
-Radix UI-based shadcn `Dialog` does not expose a callback like MUI's `onExited` or Ant Design's `afterClose`. Instead, call `close` in `onOpenChange` and schedule `unmount` with `setTimeout` for the animation duration. This handles button clicks, backdrop clicks, the Escape key, and the X button uniformly.
+shadcn `Dialog` does not expose a dedicated animation-complete callback. Call `close` in `onOpenChange` and schedule `unmount` with `setTimeout` for the animation duration. This handles button clicks, backdrop clicks, the Escape key, and the X button uniformly.
 
 <br />
 

--- a/docs/src/pages/en/docs/more/with-design-systems/shadcn.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/shadcn.mdx
@@ -103,11 +103,7 @@ export const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn('fixed inset-0 z-50 bg-black/50', className)}
-    {...props}
-  />
+  <DialogPrimitive.Overlay ref={ref} className={cn('fixed inset-0 z-50 bg-black/50', className)} {...props} />
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
@@ -172,11 +168,7 @@ export const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-gray-500', className)}
-    {...props}
-  />
+  <DialogPrimitive.Description ref={ref} className={cn('text-sm text-gray-500', className)} {...props} />
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 ```
@@ -278,11 +270,7 @@ export const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn('fixed inset-0 z-50 bg-black/50', className)}
-    {...props}
-  />
+  <DialogPrimitive.Overlay ref={ref} className={cn('fixed inset-0 z-50 bg-black/50', className)} {...props} />
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
@@ -347,11 +335,7 @@ export const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-gray-500', className)}
-    {...props}
-  />
+  <DialogPrimitive.Description ref={ref} className={cn('text-sm text-gray-500', className)} {...props} />
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 ```
@@ -455,11 +439,7 @@ export const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn('fixed inset-0 z-50 bg-black/50', className)}
-    {...props}
-  />
+  <DialogPrimitive.Overlay ref={ref} className={cn('fixed inset-0 z-50 bg-black/50', className)} {...props} />
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
@@ -524,11 +504,7 @@ export const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-gray-500', className)}
-    {...props}
-  />
+  <DialogPrimitive.Description ref={ref} className={cn('text-sm text-gray-500', className)} {...props} />
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 ```

--- a/docs/src/pages/en/docs/more/with-design-systems/shadcn.mdx
+++ b/docs/src/pages/en/docs/more/with-design-systems/shadcn.mdx
@@ -1,0 +1,536 @@
+import { Sandpack } from '@/components';
+
+# With shadcn/ui
+
+Learn how to use shadcn/ui's `Dialog` component together with `overlay-kit`.
+
+## Installation
+
+shadcn/ui copies component source code directly into your project via its CLI. Add the `Dialog` component with the command below.
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit
+npx shadcn@latest add dialog
+```
+
+`Dialog` is built on top of Radix UI. The shadcn CLI creates `components/ui/dialog.tsx` and installs the required dependencies (`@radix-ui/react-dialog`, `lucide-react`, etc.) automatically.
+
+## Basic Usage
+
+shadcn `Dialog` takes an `open` prop for visibility and `onOpenChange` for dismissal. `onOpenChange` receives a `boolean`, so calling `close()` when `!open` covers backdrop clicks and the Escape key naturally.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@radix-ui/react-dialog': '^1.1.6',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './components/ui/dialog';
+
+function App() {
+  return (
+    <button
+      className="inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Dialog open={isOpen} onOpenChange={(open) => !open && close()}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Are you sure you want to continue?</DialogTitle>
+                <DialogDescription>This action cannot be undone.</DialogDescription>
+              </DialogHeader>
+              <DialogFooter className="gap-2">
+                <button
+                  className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                  onClick={close}
+                >
+                  No
+                </button>
+                <button
+                  className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+                  onClick={close}
+                >
+                  Yes
+                </button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+```tsx components/ui/dialog.tsx
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+function cn(...classes: Array<string | undefined | false>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogPortal = DialogPrimitive.Portal;
+export const DialogClose = DialogPrimitive.Close;
+
+export const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/50', className)}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+export const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-white p-6 shadow-lg sm:rounded-lg',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+
+export const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+);
+
+export const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+export const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-gray-500', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+```
+
+</Sandpack>
+
+## Receiving Async Results
+
+Use `overlay.openAsync` to receive the user's choice as a `Promise`. Pass the result through `close(value)` on each button, and provide a default value when the dialog is dismissed via backdrop or Escape.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@radix-ui/react-dialog': '^1.1.6',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './components/ui/dialog';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <div>
+      <p className="mb-2 text-sm">Result: {result === null ? 'Not selected' : result ? 'Yes' : 'No'}</p>
+      <button
+        className="inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Dialog open={isOpen} onOpenChange={(open) => !open && close(false)}>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Are you sure you want to continue?</DialogTitle>
+                  <DialogDescription>This action cannot be undone.</DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="gap-2">
+                  <button
+                    className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                    onClick={() => close(false)}
+                  >
+                    No
+                  </button>
+                  <button
+                    className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+                    onClick={() => close(true)}
+                  >
+                    Yes
+                  </button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Open Confirm Dialog
+      </button>
+    </div>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+```tsx components/ui/dialog.tsx
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+function cn(...classes: Array<string | undefined | false>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogPortal = DialogPrimitive.Portal;
+export const DialogClose = DialogPrimitive.Close;
+
+export const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/50', className)}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+export const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-white p-6 shadow-lg sm:rounded-lg',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+
+export const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+);
+
+export const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+export const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-gray-500', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+```
+
+</Sandpack>
+
+## Releasing Memory After Animation
+
+Radix UI-based shadcn `Dialog` does not expose a callback like MUI's `onExited` or Ant Design's `afterClose`. Instead, call `close` in `onOpenChange` and schedule `unmount` with `setTimeout` for the animation duration. This handles button clicks, backdrop clicks, the Escape key, and the X button uniformly.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@radix-ui/react-dialog': '^1.1.6',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './components/ui/dialog';
+
+function App() {
+  return (
+    <button
+      className="inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Dialog
+            open={isOpen}
+            onOpenChange={(open) => {
+              if (!open) {
+                close();
+                // shadcn dialog's close animation is around 200ms.
+                setTimeout(unmount, 200);
+              }
+            }}
+          >
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Are you sure you want to continue?</DialogTitle>
+                <DialogDescription>This action cannot be undone.</DialogDescription>
+              </DialogHeader>
+              <DialogFooter className="gap-2">
+                <button
+                  className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                  onClick={close}
+                >
+                  No
+                </button>
+                <button
+                  className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+                  onClick={close}
+                >
+                  Yes
+                </button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        ));
+      }}
+    >
+      Open Confirm Dialog
+    </button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+```tsx components/ui/dialog.tsx
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+function cn(...classes: Array<string | undefined | false>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogPortal = DialogPrimitive.Portal;
+export const DialogClose = DialogPrimitive.Close;
+
+export const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/50', className)}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+export const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-white p-6 shadow-lg sm:rounded-lg',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+
+export const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+);
+
+export const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+export const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-gray-500', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+```
+
+</Sandpack>

--- a/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
@@ -17,4 +17,7 @@ export default {
   mantine: {
     title: 'Mantine',
   },
+  'headless-ui': {
+    title: 'Headless UI',
+  },
 };

--- a/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
@@ -8,4 +8,7 @@ export default {
   'ant-design': {
     title: 'Ant Design',
   },
+  shadcn: {
+    title: 'shadcn/ui',
+  },
 };

--- a/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
@@ -14,4 +14,7 @@ export default {
   'radix-ui': {
     title: 'Radix UI',
   },
+  mantine: {
+    title: 'Mantine',
+  },
 };

--- a/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/_meta.tsx
@@ -11,4 +11,7 @@ export default {
   shadcn: {
     title: 'shadcn/ui',
   },
+  'radix-ui': {
+    title: 'Radix UI',
+  },
 };

--- a/docs/src/pages/ko/docs/more/with-design-systems/chakra-ui.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/chakra-ui.mdx
@@ -6,7 +6,7 @@ Chakra UI v3의 `Dialog` 컴포넌트를 `overlay-kit`과 함께 사용하는 �
 
 ## 설치
 
-Chakra UI v3는 `@emotion/react`만 있으면 돼요. (v2와 달리 `@emotion/styled`, `framer-motion`은 필요 없어요)
+Chakra UI는 `@emotion/react`만 있으면 돼요.
 
 ```sh npm2yarn filename="shell" copy
 npm install overlay-kit @chakra-ui/react @emotion/react
@@ -139,7 +139,7 @@ export function Example() {
 
 ## 애니메이션 후 메모리 해제
 
-Chakra v3 `Dialog`는 MUI의 `onExited`나 Ant Design의 `afterClose` 같은 애니메이션 완료 콜백을 직접 제공하지 않아요. 대신 `onOpenChange`에서 `close`를 호출한 뒤 애니메이션 지속 시간만큼 `setTimeout`으로 `unmount`를 예약하는 방식이 가장 간단해요. 버튼 클릭뿐만 아니라 backdrop 클릭·ESC 키로 닫히는 경우도 모두 처리돼요.
+Chakra `Dialog`는 닫기 애니메이션이 끝나는 시점을 알려주는 콜백을 따로 제공하지 않아요. `onOpenChange`에서 `close`를 호출한 뒤 애니메이션 지속 시간만큼 `setTimeout`으로 `unmount`를 예약하는 방식이 가장 간단해요. 버튼 클릭뿐만 아니라 backdrop 클릭·ESC 키로 닫히는 경우도 모두 처리돼요.
 
 <br />
 

--- a/docs/src/pages/ko/docs/more/with-design-systems/headless-ui.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/headless-ui.mdx
@@ -1,0 +1,252 @@
+import { Sandpack } from '@/components';
+
+# Headless UI와 함께 쓰기
+
+Headless UI의 `Dialog` 컴포넌트를 `overlay-kit`과 함께 사용하는 방법을 알아볼게요.
+
+## 설치
+
+Headless UI는 스타일이 없는 헤드리스 컴포넌트이기 때문에, 예제에서는 Tailwind CSS와 함께 사용해요.
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit @headlessui/react
+```
+
+## 기본 사용법
+
+Headless UI `Dialog`는 `open` prop으로 열림 상태를, `onClose` 콜백으로 닫기 이벤트를 처리해요. `onClose`는 backdrop 클릭과 ESC 키를 누를 때 자동으로 호출되기 때문에, 여기에 `close`를 그대로 전달하면 돼요.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@headlessui/react': '^2.2.0',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle, Description } from '@headlessui/react';
+
+function App() {
+  return (
+    <button
+      className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Dialog open={isOpen} onClose={close} className="relative z-50">
+            <DialogBackdrop className="fixed inset-0 bg-black/50" />
+            <div className="fixed inset-0 flex items-center justify-center p-4">
+              <DialogPanel className="w-full max-w-md space-y-4 rounded-lg bg-white p-6 shadow-xl">
+                <DialogTitle className="text-lg font-semibold">정말로 계속하시겠어요?</DialogTitle>
+                <Description className="text-sm text-gray-500">이 작업은 되돌릴 수 없어요.</Description>
+                <div className="flex justify-end gap-2">
+                  <button
+                    className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                    onClick={close}
+                  >
+                    아니요
+                  </button>
+                  <button
+                    className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                    onClick={close}
+                  >
+                    네
+                  </button>
+                </div>
+              </DialogPanel>
+            </div>
+          </Dialog>
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## 비동기 결과 받기
+
+`overlay.openAsync`를 사용하면 사용자가 "네"를 눌렀는지 "아니요"를 눌렀는지 `Promise` 결과로 받을 수 있어요. 각 버튼에서 `close(value)`를 호출하고, `onClose`에는 backdrop·ESC로 닫힐 때의 기본값을 넣어줘요.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@headlessui/react': '^2.2.0',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle, Description } from '@headlessui/react';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <div>
+      <p className="mb-2 text-sm">결과: {result === null ? '선택 없음' : result ? '네' : '아니요'}</p>
+      <button
+        className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Dialog open={isOpen} onClose={() => close(false)} className="relative z-50">
+              <DialogBackdrop className="fixed inset-0 bg-black/50" />
+              <div className="fixed inset-0 flex items-center justify-center p-4">
+                <DialogPanel className="w-full max-w-md space-y-4 rounded-lg bg-white p-6 shadow-xl">
+                  <DialogTitle className="text-lg font-semibold">정말로 계속하시겠어요?</DialogTitle>
+                  <Description className="text-sm text-gray-500">이 작업은 되돌릴 수 없어요.</Description>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                      onClick={() => close(false)}
+                    >
+                      아니요
+                    </button>
+                    <button
+                      className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                      onClick={() => close(true)}
+                    >
+                      네
+                    </button>
+                  </div>
+                </DialogPanel>
+              </div>
+            </Dialog>
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Confirm Dialog 열기
+      </button>
+    </div>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## 애니메이션 후 메모리 해제
+
+Headless UI `Dialog`는 transition을 직접 처리하지 않고, `<Transition>` 컴포넌트로 감싸서 표시를 제어하는 패턴을 권장해요. `<Transition>`의 `afterLeave` 콜백에 `unmount`를 전달하면 닫기 애니메이션이 끝난 직후 안전하게 오버레이 메모리를 해제할 수 있어요.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@headlessui/react': '^2.2.0',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { Fragment } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+  Description,
+  Transition,
+  TransitionChild,
+} from '@headlessui/react';
+
+function App() {
+  return (
+    <button
+      className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Transition show={isOpen} as={Fragment} afterLeave={unmount}>
+            <Dialog onClose={close} className="relative z-50">
+              <TransitionChild
+                as={Fragment}
+                enter="ease-out duration-200"
+                enterFrom="opacity-0"
+                enterTo="opacity-100"
+                leave="ease-in duration-150"
+                leaveFrom="opacity-100"
+                leaveTo="opacity-0"
+              >
+                <DialogBackdrop className="fixed inset-0 bg-black/50" />
+              </TransitionChild>
+              <div className="fixed inset-0 flex items-center justify-center p-4">
+                <TransitionChild
+                  as={Fragment}
+                  enter="ease-out duration-200"
+                  enterFrom="opacity-0 scale-95"
+                  enterTo="opacity-100 scale-100"
+                  leave="ease-in duration-150"
+                  leaveFrom="opacity-100 scale-100"
+                  leaveTo="opacity-0 scale-95"
+                >
+                  <DialogPanel className="w-full max-w-md space-y-4 rounded-lg bg-white p-6 shadow-xl">
+                    <DialogTitle className="text-lg font-semibold">정말로 계속하시겠어요?</DialogTitle>
+                    <Description className="text-sm text-gray-500">이 작업은 되돌릴 수 없어요.</Description>
+                    <div className="flex justify-end gap-2">
+                      <button
+                        className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                        onClick={close}
+                      >
+                        아니요
+                      </button>
+                      <button
+                        className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                        onClick={close}
+                      >
+                        네
+                      </button>
+                    </div>
+                  </DialogPanel>
+                </TransitionChild>
+              </div>
+            </Dialog>
+          </Transition>
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>

--- a/docs/src/pages/ko/docs/more/with-design-systems/mantine.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/mantine.mdx
@@ -146,12 +146,7 @@ function App() {
     <Button
       onClick={() => {
         overlay.open(({ isOpen, close, unmount }) => (
-          <Modal
-            opened={isOpen}
-            onClose={close}
-            title="정말로 계속하시겠어요?"
-            transitionProps={{ onExited: unmount }}
-          >
+          <Modal opened={isOpen} onClose={close} title="정말로 계속하시겠어요?" transitionProps={{ onExited: unmount }}>
             <Group justify="flex-end" gap="sm">
               <Button variant="default" onClick={close}>
                 아니요

--- a/docs/src/pages/ko/docs/more/with-design-systems/mantine.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/mantine.mdx
@@ -1,0 +1,181 @@
+import { Sandpack } from '@/components';
+
+# Mantine과 함께 쓰기
+
+Mantine의 `Modal` 컴포넌트를 `overlay-kit`과 함께 사용하는 방법을 알아볼게요.
+
+## 설치
+
+Mantine 코어 패키지와 hooks 패키지를 함께 설치하고, 루트에 스타일시트를 import 해야 해요.
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit @mantine/core @mantine/hooks
+```
+
+## 기본 사용법
+
+Mantine `Modal`은 `opened` prop으로 열림 상태를, `onClose` 콜백으로 닫기 이벤트를 처리해요. 앱 루트는 `MantineProvider`로 감싸야 하고, `@mantine/core/styles.css`를 import 해야 모달이 정상적으로 보여요.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@mantine/core': '^7.13.0',
+    '@mantine/hooks': '^7.13.0',
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Button, MantineProvider, Modal, Group } from '@mantine/core';
+import '@mantine/core/styles.css';
+
+function App() {
+  return (
+    <Button
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Modal opened={isOpen} onClose={close} title="정말로 계속하시겠어요?">
+            <Group justify="flex-end" gap="sm">
+              <Button variant="default" onClick={close}>
+                아니요
+              </Button>
+              <Button onClick={close}>네</Button>
+            </Group>
+          </Modal>
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <MantineProvider>
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
+    </MantineProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## 비동기 결과 받기
+
+`overlay.openAsync`로 사용자의 선택을 `Promise`로 받을 수 있어요. 각 버튼의 `close(value)`에 결과를 넘기고, `onClose`에서는 backdrop·ESC로 닫힐 때의 기본값을 넘겨요.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@mantine/core': '^7.13.0',
+    '@mantine/hooks': '^7.13.0',
+  }}
+>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Button, MantineProvider, Modal, Group, Text } from '@mantine/core';
+import '@mantine/core/styles.css';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <Group align="center" gap="md">
+      <Text size="sm">결과: {result === null ? '선택 없음' : result ? '네' : '아니요'}</Text>
+      <Button
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Modal opened={isOpen} onClose={() => close(false)} title="정말로 계속하시겠어요?">
+              <Group justify="flex-end" gap="sm">
+                <Button variant="default" onClick={() => close(false)}>
+                  아니요
+                </Button>
+                <Button onClick={() => close(true)}>네</Button>
+              </Group>
+            </Modal>
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Confirm Dialog 열기
+      </Button>
+    </Group>
+  );
+}
+
+export function Example() {
+  return (
+    <MantineProvider>
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
+    </MantineProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## 애니메이션 후 메모리 해제
+
+Mantine `Modal`은 `transitionProps`를 통해 transition 콜백을 받을 수 있어요. `transitionProps.onExited`에 `unmount`를 전달하면 애니메이션이 끝난 직후 안전하게 오버레이 메모리를 해제할 수 있어요.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@mantine/core': '^7.13.0',
+    '@mantine/hooks': '^7.13.0',
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import { Button, MantineProvider, Modal, Group } from '@mantine/core';
+import '@mantine/core/styles.css';
+
+function App() {
+  return (
+    <Button
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Modal
+            opened={isOpen}
+            onClose={close}
+            title="정말로 계속하시겠어요?"
+            transitionProps={{ onExited: unmount }}
+          >
+            <Group justify="flex-end" gap="sm">
+              <Button variant="default" onClick={close}>
+                아니요
+              </Button>
+              <Button onClick={close}>네</Button>
+            </Group>
+          </Modal>
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </Button>
+  );
+}
+
+export function Example() {
+  return (
+    <MantineProvider>
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
+    </MantineProvider>
+  );
+}
+```
+
+</Sandpack>

--- a/docs/src/pages/ko/docs/more/with-design-systems/radix-ui.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/radix-ui.mdx
@@ -42,9 +42,7 @@ function App() {
               <Dialog.Overlay className="fixed inset-0 bg-black/50" />
               <Dialog.Content className="fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-white p-6 shadow-lg">
                 <Dialog.Title className="text-lg font-semibold">정말로 계속하시겠어요?</Dialog.Title>
-                <Dialog.Description className="text-sm text-gray-500">
-                  이 작업은 되돌릴 수 없어요.
-                </Dialog.Description>
+                <Dialog.Description className="text-sm text-gray-500">이 작업은 되돌릴 수 없어요.</Dialog.Description>
                 <div className="flex justify-end gap-2">
                   <button
                     className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
@@ -116,9 +114,7 @@ function App() {
                 <Dialog.Overlay className="fixed inset-0 bg-black/50" />
                 <Dialog.Content className="fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-white p-6 shadow-lg">
                   <Dialog.Title className="text-lg font-semibold">정말로 계속하시겠어요?</Dialog.Title>
-                  <Dialog.Description className="text-sm text-gray-500">
-                    이 작업은 되돌릴 수 없어요.
-                  </Dialog.Description>
+                  <Dialog.Description className="text-sm text-gray-500">이 작업은 되돌릴 수 없어요.</Dialog.Description>
                   <div className="flex justify-end gap-2">
                     <button
                       className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
@@ -196,9 +192,7 @@ function App() {
               <Dialog.Overlay className="fixed inset-0 bg-black/50 transition-opacity data-[state=closed]:opacity-0 data-[state=open]:opacity-100" />
               <Dialog.Content className="fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-white p-6 shadow-lg transition-opacity data-[state=closed]:opacity-0 data-[state=open]:opacity-100">
                 <Dialog.Title className="text-lg font-semibold">정말로 계속하시겠어요?</Dialog.Title>
-                <Dialog.Description className="text-sm text-gray-500">
-                  이 작업은 되돌릴 수 없어요.
-                </Dialog.Description>
+                <Dialog.Description className="text-sm text-gray-500">이 작업은 되돌릴 수 없어요.</Dialog.Description>
                 <div className="flex justify-end gap-2">
                   <button
                     className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"

--- a/docs/src/pages/ko/docs/more/with-design-systems/radix-ui.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/radix-ui.mdx
@@ -1,0 +1,236 @@
+import { Sandpack } from '@/components';
+
+# Radix UI와 함께 쓰기
+
+Radix UI의 `Dialog` primitives를 `overlay-kit`과 함께 사용하는 방법을 알아볼게요.
+
+## 설치
+
+Radix `Dialog` 패키지를 설치해요. Radix UI는 스타일이 없는 헤드리스 컴포넌트이기 때문에, 예제에서는 Tailwind CSS와 함께 사용해요.
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit @radix-ui/react-dialog
+```
+
+## 기본 사용법
+
+Radix `Dialog.Root`는 `open` prop으로 열림 상태를, `onOpenChange`로 닫기 이벤트를 처리해요. `onOpenChange`는 `boolean`을 인자로 받기 때문에 `!open`일 때 `close()`를 호출해주면 backdrop 클릭·ESC 키로 닫히는 경우까지 자연스럽게 처리돼요.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@radix-ui/react-dialog': '^1.1.6',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import * as Dialog from '@radix-ui/react-dialog';
+
+function App() {
+  return (
+    <button
+      className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Dialog.Root open={isOpen} onOpenChange={(open) => !open && close()}>
+            <Dialog.Portal>
+              <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+              <Dialog.Content className="fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-white p-6 shadow-lg">
+                <Dialog.Title className="text-lg font-semibold">정말로 계속하시겠어요?</Dialog.Title>
+                <Dialog.Description className="text-sm text-gray-500">
+                  이 작업은 되돌릴 수 없어요.
+                </Dialog.Description>
+                <div className="flex justify-end gap-2">
+                  <button
+                    className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                    onClick={close}
+                  >
+                    아니요
+                  </button>
+                  <button
+                    className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+                    onClick={close}
+                  >
+                    네
+                  </button>
+                </div>
+              </Dialog.Content>
+            </Dialog.Portal>
+          </Dialog.Root>
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## 비동기 결과 받기
+
+`overlay.openAsync`를 사용하면 사용자가 "네"를 눌렀는지 "아니요"를 눌렀는지 `Promise` 결과로 받을 수 있어요. 각 버튼에서 `close(value)`로 결과를 넘기고, `onOpenChange`에서는 backdrop·ESC로 닫힐 때 기본값을 넣어줘요.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@radix-ui/react-dialog': '^1.1.6',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import * as Dialog from '@radix-ui/react-dialog';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <div>
+      <p className="mb-2 text-sm">결과: {result === null ? '선택 없음' : result ? '네' : '아니요'}</p>
+      <button
+        className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Dialog.Root open={isOpen} onOpenChange={(open) => !open && close(false)}>
+              <Dialog.Portal>
+                <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+                <Dialog.Content className="fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-white p-6 shadow-lg">
+                  <Dialog.Title className="text-lg font-semibold">정말로 계속하시겠어요?</Dialog.Title>
+                  <Dialog.Description className="text-sm text-gray-500">
+                    이 작업은 되돌릴 수 없어요.
+                  </Dialog.Description>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                      onClick={() => close(false)}
+                    >
+                      아니요
+                    </button>
+                    <button
+                      className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+                      onClick={() => close(true)}
+                    >
+                      네
+                    </button>
+                  </div>
+                </Dialog.Content>
+              </Dialog.Portal>
+            </Dialog.Root>
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Confirm Dialog 열기
+      </button>
+    </div>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>
+
+## 애니메이션 후 메모리 해제
+
+Radix `Dialog`는 MUI의 `onExited`나 Ant Design의 `afterClose` 같은 애니메이션 완료 콜백을 직접 제공하지 않아요. 대신 `onOpenChange`에서 `close`를 호출한 뒤 애니메이션 지속 시간만큼 `setTimeout`으로 `unmount`를 예약하면 버튼·backdrop 클릭·ESC 키까지 모두 처리할 수 있어요.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@radix-ui/react-dialog': '^1.1.6',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import * as Dialog from '@radix-ui/react-dialog';
+
+function App() {
+  return (
+    <button
+      className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Dialog.Root
+            open={isOpen}
+            onOpenChange={(open) => {
+              if (!open) {
+                close();
+                // Radix dialog 기본 닫기 애니메이션은 약 150ms예요.
+                setTimeout(unmount, 200);
+              }
+            }}
+          >
+            <Dialog.Portal>
+              <Dialog.Overlay className="fixed inset-0 bg-black/50 transition-opacity data-[state=closed]:opacity-0 data-[state=open]:opacity-100" />
+              <Dialog.Content className="fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-white p-6 shadow-lg transition-opacity data-[state=closed]:opacity-0 data-[state=open]:opacity-100">
+                <Dialog.Title className="text-lg font-semibold">정말로 계속하시겠어요?</Dialog.Title>
+                <Dialog.Description className="text-sm text-gray-500">
+                  이 작업은 되돌릴 수 없어요.
+                </Dialog.Description>
+                <div className="flex justify-end gap-2">
+                  <button
+                    className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                    onClick={close}
+                  >
+                    아니요
+                  </button>
+                  <button
+                    className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+                    onClick={close}
+                  >
+                    네
+                  </button>
+                </div>
+              </Dialog.Content>
+            </Dialog.Portal>
+          </Dialog.Root>
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+</Sandpack>

--- a/docs/src/pages/ko/docs/more/with-design-systems/radix-ui.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/radix-ui.mdx
@@ -159,7 +159,7 @@ export function Example() {
 
 ## 애니메이션 후 메모리 해제
 
-Radix `Dialog`는 MUI의 `onExited`나 Ant Design의 `afterClose` 같은 애니메이션 완료 콜백을 직접 제공하지 않아요. 대신 `onOpenChange`에서 `close`를 호출한 뒤 애니메이션 지속 시간만큼 `setTimeout`으로 `unmount`를 예약하면 버튼·backdrop 클릭·ESC 키까지 모두 처리할 수 있어요.
+Radix `Dialog`는 닫기 애니메이션이 끝나는 시점을 알려주는 콜백을 따로 제공하지 않아요. `onOpenChange`에서 `close`를 호출한 뒤 애니메이션 지속 시간만큼 `setTimeout`으로 `unmount`를 예약하면 버튼·backdrop 클릭·ESC 키까지 모두 처리할 수 있어요.
 
 <br />
 

--- a/docs/src/pages/ko/docs/more/with-design-systems/shadcn.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/shadcn.mdx
@@ -103,11 +103,7 @@ export const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn('fixed inset-0 z-50 bg-black/50', className)}
-    {...props}
-  />
+  <DialogPrimitive.Overlay ref={ref} className={cn('fixed inset-0 z-50 bg-black/50', className)} {...props} />
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
@@ -172,11 +168,7 @@ export const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-gray-500', className)}
-    {...props}
-  />
+  <DialogPrimitive.Description ref={ref} className={cn('text-sm text-gray-500', className)} {...props} />
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 ```
@@ -278,11 +270,7 @@ export const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn('fixed inset-0 z-50 bg-black/50', className)}
-    {...props}
-  />
+  <DialogPrimitive.Overlay ref={ref} className={cn('fixed inset-0 z-50 bg-black/50', className)} {...props} />
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
@@ -347,11 +335,7 @@ export const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-gray-500', className)}
-    {...props}
-  />
+  <DialogPrimitive.Description ref={ref} className={cn('text-sm text-gray-500', className)} {...props} />
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 ```
@@ -455,11 +439,7 @@ export const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn('fixed inset-0 z-50 bg-black/50', className)}
-    {...props}
-  />
+  <DialogPrimitive.Overlay ref={ref} className={cn('fixed inset-0 z-50 bg-black/50', className)} {...props} />
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
@@ -524,11 +504,7 @@ export const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-gray-500', className)}
-    {...props}
-  />
+  <DialogPrimitive.Description ref={ref} className={cn('text-sm text-gray-500', className)} {...props} />
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 ```

--- a/docs/src/pages/ko/docs/more/with-design-systems/shadcn.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/shadcn.mdx
@@ -360,7 +360,7 @@ DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 ## 애니메이션 후 메모리 해제
 
-Radix UI 기반의 shadcn `Dialog`는 MUI의 `onExited`나 Ant Design의 `afterClose` 같은 애니메이션 완료 콜백을 직접 제공하지 않아요. 대신 `onOpenChange`에서 `close`를 호출한 뒤 애니메이션 지속 시간만큼 `setTimeout`으로 `unmount`를 예약하면 버튼·backdrop 클릭·ESC 키·X 버튼까지 모두 처리돼요.
+shadcn `Dialog`는 닫기 애니메이션이 끝나는 시점을 알려주는 콜백을 따로 제공하지 않아요. `onOpenChange`에서 `close`를 호출한 뒤 애니메이션 지속 시간만큼 `setTimeout`으로 `unmount`를 예약하면 버튼·backdrop 클릭·ESC 키·X 버튼까지 모두 처리돼요.
 
 <br />
 

--- a/docs/src/pages/ko/docs/more/with-design-systems/shadcn.mdx
+++ b/docs/src/pages/ko/docs/more/with-design-systems/shadcn.mdx
@@ -1,0 +1,536 @@
+import { Sandpack } from '@/components';
+
+# shadcn/ui와 함께 쓰기
+
+shadcn/ui의 `Dialog` 컴포넌트를 `overlay-kit`과 함께 사용하는 방법을 알아볼게요.
+
+## 설치
+
+shadcn/ui는 CLI로 컴포넌트 코드를 프로젝트에 직접 복사해서 써요. 다음 명령어로 `Dialog`를 추가해요.
+
+```sh npm2yarn filename="shell" copy
+npm install overlay-kit
+npx shadcn@latest add dialog
+```
+
+`Dialog`는 Radix UI 기반으로 동작해요. shadcn CLI가 `components/ui/dialog.tsx` 파일을 만들고, 필요한 의존성(`@radix-ui/react-dialog`, `lucide-react` 등)을 자동으로 설치해줘요.
+
+## 기본 사용법
+
+shadcn `Dialog`는 `open` prop으로 열림 상태를, `onOpenChange`로 닫기 이벤트를 처리해요. `onOpenChange`는 `boolean`을 인자로 받기 때문에 `!open`일 때 `close()`를 호출해주면 backdrop 클릭·ESC 키로 닫히는 경우까지 자연스럽게 처리돼요.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@radix-ui/react-dialog': '^1.1.6',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './components/ui/dialog';
+
+function App() {
+  return (
+    <button
+      className="inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          <Dialog open={isOpen} onOpenChange={(open) => !open && close()}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>정말로 계속하시겠어요?</DialogTitle>
+                <DialogDescription>이 작업은 되돌릴 수 없어요.</DialogDescription>
+              </DialogHeader>
+              <DialogFooter className="gap-2">
+                <button
+                  className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                  onClick={close}
+                >
+                  아니요
+                </button>
+                <button
+                  className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+                  onClick={close}
+                >
+                  네
+                </button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+```tsx components/ui/dialog.tsx
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+function cn(...classes: Array<string | undefined | false>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogPortal = DialogPrimitive.Portal;
+export const DialogClose = DialogPrimitive.Close;
+
+export const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/50', className)}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+export const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-white p-6 shadow-lg sm:rounded-lg',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+
+export const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+);
+
+export const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+export const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-gray-500', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+```
+
+</Sandpack>
+
+## 비동기 결과 받기
+
+`overlay.openAsync`를 사용하면 사용자가 "네"를 눌렀는지 "아니요"를 눌렀는지 `Promise` 결과로 받을 수 있어요. 각 버튼의 `close(value)`에 결과를 전달하고, `onOpenChange`에서 backdrop·ESC로 닫힐 때는 기본값을 넘겨주면 돼요.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@radix-ui/react-dialog': '^1.1.6',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { useState } from 'react';
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './components/ui/dialog';
+
+function App() {
+  const [result, setResult] = useState<boolean | null>(null);
+
+  return (
+    <div>
+      <p className="mb-2 text-sm">결과: {result === null ? '선택 없음' : result ? '네' : '아니요'}</p>
+      <button
+        className="inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+        onClick={async () => {
+          const confirmed = await overlay.openAsync<boolean>(({ isOpen, close }) => (
+            <Dialog open={isOpen} onOpenChange={(open) => !open && close(false)}>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>정말로 계속하시겠어요?</DialogTitle>
+                  <DialogDescription>이 작업은 되돌릴 수 없어요.</DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="gap-2">
+                  <button
+                    className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                    onClick={() => close(false)}
+                  >
+                    아니요
+                  </button>
+                  <button
+                    className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+                    onClick={() => close(true)}
+                  >
+                    네
+                  </button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          ));
+          setResult(confirmed);
+        }}
+      >
+        Confirm Dialog 열기
+      </button>
+    </div>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+```tsx components/ui/dialog.tsx
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+function cn(...classes: Array<string | undefined | false>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogPortal = DialogPrimitive.Portal;
+export const DialogClose = DialogPrimitive.Close;
+
+export const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/50', className)}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+export const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-white p-6 shadow-lg sm:rounded-lg',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+
+export const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+);
+
+export const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+export const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-gray-500', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+```
+
+</Sandpack>
+
+## 애니메이션 후 메모리 해제
+
+Radix UI 기반의 shadcn `Dialog`는 MUI의 `onExited`나 Ant Design의 `afterClose` 같은 애니메이션 완료 콜백을 직접 제공하지 않아요. 대신 `onOpenChange`에서 `close`를 호출한 뒤 애니메이션 지속 시간만큼 `setTimeout`으로 `unmount`를 예약하면 버튼·backdrop 클릭·ESC 키·X 버튼까지 모두 처리돼요.
+
+<br />
+
+<Sandpack
+  dependencies={{
+    '@radix-ui/react-dialog': '^1.1.6',
+  }}
+  providerOptions={{
+    externalResources: ['https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'],
+  }}
+>
+
+```tsx Example.tsx active
+import { OverlayProvider, overlay } from 'overlay-kit';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './components/ui/dialog';
+
+function App() {
+  return (
+    <button
+      className="inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+      onClick={() => {
+        overlay.open(({ isOpen, close, unmount }) => (
+          <Dialog
+            open={isOpen}
+            onOpenChange={(open) => {
+              if (!open) {
+                close();
+                // shadcn dialog의 기본 닫기 애니메이션은 약 200ms예요.
+                setTimeout(unmount, 200);
+              }
+            }}
+          >
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>정말로 계속하시겠어요?</DialogTitle>
+                <DialogDescription>이 작업은 되돌릴 수 없어요.</DialogDescription>
+              </DialogHeader>
+              <DialogFooter className="gap-2">
+                <button
+                  className="rounded-md border border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+                  onClick={close}
+                >
+                  아니요
+                </button>
+                <button
+                  className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+                  onClick={close}
+                >
+                  네
+                </button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        ));
+      }}
+    >
+      Confirm Dialog 열기
+    </button>
+  );
+}
+
+export function Example() {
+  return (
+    <OverlayProvider>
+      <App />
+    </OverlayProvider>
+  );
+}
+```
+
+```tsx components/ui/dialog.tsx
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+function cn(...classes: Array<string | undefined | false>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogPortal = DialogPrimitive.Portal;
+export const DialogClose = DialogPrimitive.Close;
+
+export const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/50', className)}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+export const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-white p-6 shadow-lg sm:rounded-lg',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+
+export const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+);
+
+export const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+export const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-gray-500', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+```
+
+</Sandpack>


### PR DESCRIPTION
## Summary

- Add integration guides for shadcn/ui, Radix UI, Mantine, and Headless UI under `docs/.../with-design-systems`, each with `기본 사용법 / 비동기 결과 / 메모리 해제` sections and live Sandpack examples (ko + en).
- Wire the new entries into the `_meta.tsx` navigation in both locales.
- Drop cross-library and cross-version comparisons (e.g. "v2와 달리...", "Unlike MUI's `onExited`...") from existing guides so each guide focuses on its own library and overlay-kit integration.

## Commits

- `docs: Add shadcn/ui integration guide` — Radix-based shadcn `<Dialog>` + Tailwind CDN, with a copy of `components/ui/dialog.tsx` inside Sandpack.
- `docs: Add Radix UI integration guide` — Raw Radix primitives with Tailwind CDN, \`onOpenChange\` + \`setTimeout(unmount, 200)\` pattern.
- `docs: Add Mantine integration guide` — \`MantineProvider\` + \`@mantine/core/styles.css\`, \`transitionProps.onExited={unmount}\`.
- `docs: Add Headless UI integration guide` — \`DialogBackdrop\`/\`DialogPanel\` + Tailwind CDN, \`<Transition afterLeave={unmount}>\` for safe memory release.
- `docs: Drop cross-library and version comparisons from design system guides` — Cleanup so each guide reads as overlay-kit + that single library.

## Test plan

- [ ] \`yarn dev\` in \`docs/\` and visit each new page in both locales:
  - \`/ko/docs/more/with-design-systems/shadcn\`, \`/radix-ui\`, \`/mantine\`, \`/headless-ui\`
  - \`/en/docs/more/with-design-systems/shadcn\`, \`/radix-ui\`, \`/mantine\`, \`/headless-ui\`
- [ ] Confirm sidebar order: Material UI → Chakra UI → Ant Design → shadcn/ui → Radix UI → Mantine → Headless UI.
- [ ] In each Sandpack preview, click the trigger and verify Confirm Dialog opens; close via primary/secondary button, backdrop click, ESC key (and X button for shadcn).
- [ ] Verify the "Releasing Memory After Animation" example actually unmounts after the close transition (e.g. via React DevTools or a console log next to \`unmount\`).
- [ ] Spot-check that existing Material UI / Chakra UI / Ant Design guides still render correctly after the cleanup commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)